### PR TITLE
Update abilities.ts

### DIFF
--- a/data/mods/m4av6/abilities.ts
+++ b/data/mods/m4av6/abilities.ts
@@ -136,7 +136,7 @@ export const BattleAbilities: {[k: string]: ModdedAbilityData} = {
 			}
 		},
 		onBasePowerPriority: 9,
-		onBasePower(basePower, attacker, defender, move) {
+		onBasePower(basePower, pokemon, move) {
 			if (move.type === 'Electric' && pokemon.side.faintedLastTurn) {
 				this.debug('tempestuous boost');
 				return this.chainModify(2);


### PR DESCRIPTION
Fix crash with Ability Tempestuous on using an Electric-type move

This was entirely my fault, oops... I'm pretty sure that changing this bit should stop the crash - I'm sorry I didn't catch it at first!