### PR TITLE
[Sylvemons] Bugfixes

### DIFF
--- a/data/mods/sylvemonstest/abilities.ts
+++ b/data/mods/sylvemonstest/abilities.ts
@@ -672,10 +672,11 @@ export const BattleAbilities: {[k: string]: ModdedAbilityData} = {
 			if (!this.field.isWeather(['shadowsky'])) return;
 			let stat = 'atk';
 			let bestStat = 0;
-			for (let i in pokemon.stats) {
-				if (pokemon.stats[i] > bestStat) {
+			let i: StatNameExceptHP;
+			for (let i in pokemon.storedStats) {
+				if (pokemon.storedStats[i] > bestStat) {
 					stat = i;
-					bestStat = pokemon.stats[i];
+					bestStat = pokemon.storedStats[i];
 				}
 			}
 			this.boost({[stat]: 1}, pokemon);
@@ -938,16 +939,28 @@ export const BattleAbilities: {[k: string]: ModdedAbilityData} = {
        num: 170,
     },
 	
-    "cursedbody": {
-        shortDesc: "On switch-in, the opposing Pokemon is taunted.",
-        onStart(source) {
-            this.useMove("Taunt", source);
-        },
-        id: "cursedbody",
-        name: "Cursed Body",
-        rating: 2,
-        num: 130,
-    },
+	"cursedbody": {
+		shortDesc: "On switch-in, the opposing Pokémon is taunted unless it has a Substitute.",
+		onStart(pokemon) {
+			let activated = false;
+			for (const target of pokemon.side.foe.active) {
+				if (!target || !this.isAdjacent(target, pokemon)) continue;
+				if (!activated) {
+					this.add('-ability', pokemon, 'Cursed Body');
+					activated = true;
+				}
+				if (target.volatiles['substitute']) {
+					this.add('-immune', target);
+				} else {
+					target.addVolatile('taunt');
+				}
+			}
+		},
+		id: "cursedbody",
+		name: "Cursed Body",
+		rating: 2,
+		num: 130,
+	},
 	
     "loudspeaker": {
         desc: "Boosts the power of sound-based moves.",

--- a/data/mods/sylvemonstest/abilities.ts
+++ b/data/mods/sylvemonstest/abilities.ts
@@ -1010,6 +1010,7 @@ export const BattleAbilities: {[k: string]: ModdedAbilityData} = {
 			if (target === this.effectData.target) {
 				let b: BoostName;
 				for (b in boost) {
+					let activated = false;
 					const bouncedBoost: SparseBoostsTable = {};
 					bouncedBoost[b] = boost[b];
 					if (!activated) {
@@ -1025,6 +1026,7 @@ export const BattleAbilities: {[k: string]: ModdedAbilityData} = {
 			} else {
 				let b: BoostName;
 				for (b in boost) {
+					let activated = false;
 					const stolenBoost: SparseBoostsTable = {};
 					stolenBoost[b] = boost[b];
 					if (!activated) {

--- a/data/mods/sylvemonstest/abilities.ts
+++ b/data/mods/sylvemonstest/abilities.ts
@@ -1004,7 +1004,7 @@ export const BattleAbilities: {[k: string]: ModdedAbilityData} = {
 	"mindtrick": {
 		desc: "When this Pokémon's stat stages would be modified, other Pokémon's stat stages are modified instead. When other Pokémon's stat stages would be modified, this Pokémon's stat stages are modified instead.",
 		shortDesc: "Stat changes on this Pokémon are reflected back to the attacker.",
-		onBoost(boost, target, source, effect) {
+		onAnyBoost(boost, target, source, effect) {
 			// Don't bounce self stat changes, or boosts that have already bounced
 			if (!boost || effect.id === 'mirrorarmor' || effect.id === 'mindtrick') return;
 			if (target === this.effectData.target) {

--- a/data/mods/sylvemonstest/abilities.ts
+++ b/data/mods/sylvemonstest/abilities.ts
@@ -1012,7 +1012,10 @@ export const BattleAbilities: {[k: string]: ModdedAbilityData} = {
 				for (b in boost) {
 					const bouncedBoost: SparseBoostsTable = {};
 					bouncedBoost[b] = boost[b];
-					this.add('-ability', this.effectData.target, 'Mind Trick');
+					if (!activated) {
+						this.add('-ability', this.effectData.target, 'Mind Trick');
+						activated = true;
+					}
 					delete boost[b];
 					for (const pokemon of this.getAllActive()) {
 						if (pokemon === this.effectData.target || pokemon.fainted) continue;
@@ -1024,7 +1027,10 @@ export const BattleAbilities: {[k: string]: ModdedAbilityData} = {
 				for (b in boost) {
 					const stolenBoost: SparseBoostsTable = {};
 					stolenBoost[b] = boost[b];
-					this.add('-ability', this.effectData.target, 'Mind Trick');
+					if (!activated) {
+						this.add('-ability', this.effectData.target, 'Mind Trick');
+						activated = true;
+					}
 					delete boost[b];
 					this.boost(stolenBoost, this.effectData.target, this.effectData.target, null, true);
 				}

--- a/data/mods/sylvemonstest/abilities.ts
+++ b/data/mods/sylvemonstest/abilities.ts
@@ -1022,4 +1022,38 @@ export const BattleAbilities: {[k: string]: ModdedAbilityData} = {
         rating: 3,
         num: 4,
     },
+
+	mindtrick: {
+		desc: "When this Pokémon's stat stages would be modified, other Pokémon's stat stages are modified instead. When other Pokémon's stat stages would be modified, this Pokémon's stat stages are modified instead.",
+		shortDesc: "Stat changes on this Pokémon are reflected back to the attacker.",
+		onBoost(boost, target, source, effect) {
+			// Don't bounce self stat changes, or boosts that have already bounced
+			if (!boost || effect.id === 'mirrorarmor' || effect.id === 'mindtrick') return;
+			if (target === source) {
+				let b: BoostName;
+				for (b in boost) {
+					const bouncedBoost: SparseBoostsTable = {};
+					bouncedBoost[b] = boost[b];
+					delete boost[b];
+					this.add('-ability', this.effectData.target, 'Mind Trick');
+					for (const pokemon of this.getAllActive()) {
+						if (pokemon === this.effectData.target || pokemon.fainted) continue;
+						this.boost(bouncedBoost, pokemon, this.effectData.target, null, true);
+					}
+				}
+			} else {
+				let b: BoostName;
+				for (b in boost) {
+					const stolenBoost: SparseBoostsTable = {};
+					stolenBoost[b] = boost[b];
+					delete boost[b];
+					this.add('-ability', this.effectData.target, 'Mind Trick');
+					this.boost(stolenBoost, this.effectData.target, this.effectData.target, null, true);
+				}
+			}
+		},
+		name: "Mirror Armor",
+		rating: 2,
+		num: 240,
+	},
 };

--- a/data/mods/sylvemonstest/abilities.ts
+++ b/data/mods/sylvemonstest/abilities.ts
@@ -893,41 +893,6 @@ export const BattleAbilities: {[k: string]: ModdedAbilityData} = {
 		name: "Bloodsucker",
 	},
 	
-	"zenmode": {
-		desc: "If this Pokemon is a Darmanitan, it changes to Zen Mode if it has 1/2 or less of its maximum HP at the end of a turn. If Darmanitan's HP is above 1/2 of its maximum HP at the end of a turn, it changes back to Standard Mode. This Ability cannot be removed or suppressed.",
-		shortDesc: "If Darmanitan, at end of turn changes Mode to Standard if > 1/2 max HP, else Zen.",
-		onResidualOrder: 27,
-		onResidual(pokemon) {
-			if (pokemon.baseSpecies.baseSpecies !== 'Darmanitan' || pokemon.transformed) {
-				return;
-			}
-			if ((pokemon.hp <= pokemon.maxhp / 2 || pokemon.hasItem('ragecandybar')) && pokemon.species.speciesid === 'darmanitan') {
-				pokemon.addVolatile('zenmode');
-			} else if (pokemon.hp > pokemon.maxhp / 2 && pokemon.species.speciesid === 'darmanitanzen') {
-				pokemon.addVolatile('zenmode'); // in case of base Darmanitan-Zen
-				pokemon.removeVolatile('zenmode');
-			}
-		},
-		onEnd(pokemon) {
-			if (!pokemon.volatiles['zenmode'] || !pokemon.hp) return;
-			pokemon.transformed = false;
-			delete pokemon.volatiles['zenmode'];
-			pokemon.formeChange('Darmanitan', this.effect, false, '[silent]');
-		},
-		effect: {
-			onStart(pokemon) {
-				if (pokemon.species.speciesid !== 'darmanitanzen') pokemon.formeChange('Darmanitan-Zen');
-			},
-			onEnd(pokemon) {
-				pokemon.formeChange('Darmanitan');
-			},
-		},
-		id: "zenmode",
-		name: "Zen Mode",
-		rating: -1,
-		num: 161,
-	},
-	
 	 "magician": {
        shortDesc: "On switch-in, this Pokemon switches its item with the opponent's.",
        onStart(source) {
@@ -1036,19 +1001,19 @@ export const BattleAbilities: {[k: string]: ModdedAbilityData} = {
         num: 4,
     },
 
-	mindtrick: {
+	"mindtrick": {
 		desc: "When this Pokémon's stat stages would be modified, other Pokémon's stat stages are modified instead. When other Pokémon's stat stages would be modified, this Pokémon's stat stages are modified instead.",
 		shortDesc: "Stat changes on this Pokémon are reflected back to the attacker.",
 		onBoost(boost, target, source, effect) {
 			// Don't bounce self stat changes, or boosts that have already bounced
 			if (!boost || effect.id === 'mirrorarmor' || effect.id === 'mindtrick') return;
-			if (target === source) {
+			if (target === this.effectData.target) {
 				let b: BoostName;
 				for (b in boost) {
 					const bouncedBoost: SparseBoostsTable = {};
 					bouncedBoost[b] = boost[b];
-					delete boost[b];
 					this.add('-ability', this.effectData.target, 'Mind Trick');
+					delete boost[b];
 					for (const pokemon of this.getAllActive()) {
 						if (pokemon === this.effectData.target || pokemon.fainted) continue;
 						this.boost(bouncedBoost, pokemon, this.effectData.target, null, true);
@@ -1059,14 +1024,14 @@ export const BattleAbilities: {[k: string]: ModdedAbilityData} = {
 				for (b in boost) {
 					const stolenBoost: SparseBoostsTable = {};
 					stolenBoost[b] = boost[b];
-					delete boost[b];
 					this.add('-ability', this.effectData.target, 'Mind Trick');
+					delete boost[b];
 					this.boost(stolenBoost, this.effectData.target, this.effectData.target, null, true);
 				}
 			}
 		},
-		name: "Mirror Armor",
+		id: "mindtrick",
+		name: "Mind Trick",
 		rating: 2,
-		num: 240,
 	},
 };

--- a/data/mods/sylvemonstest/items.ts
+++ b/data/mods/sylvemonstest/items.ts
@@ -11,6 +11,10 @@ export const BattleItems: {[k: string]: ModdedItemData} = {
 			basePower: 30,
 		},
 		onTakeItem: false,
+		onModifyMovePriority: -5,
+		onSourceModifyMove(move) {
+			move.ignoreImmunity = true;
+		},
 		onStart(target) {
 			this.add('-item', target, 'Reverse Core');
 			this.add('-message', `${target.name} is cloaked in a mysterious power!`);

--- a/data/mods/sylvemonstest/items.ts
+++ b/data/mods/sylvemonstest/items.ts
@@ -21,11 +21,8 @@ export const BattleItems: {[k: string]: ModdedItemData} = {
 			this.add('-item', pokemon, pokemon.getItem());
 		},
 		onModifyMovePriority: -5,
-		onSourceModifyMove(move) {
-			move.ignoreImmunity = true;
-		},
 		onEffectiveness(typeMod, target, type, move) {
-				if (move && !this.getImmunity(move, type)) return 1;
+				if (move && this.dex.getImmunity(move, type) === false) return 3;
 				return typeMod * -1;
 			},
 		desc: "Holder's weaknesses and resistances (including immunities) are swapped like in an Inverse Battle.",

--- a/data/mods/sylvemonstest/items.ts
+++ b/data/mods/sylvemonstest/items.ts
@@ -17,7 +17,7 @@ export const BattleItems: {[k: string]: ModdedItemData} = {
 		},
 		onModifyMovePriority: -5,
 		onEffectiveness(typeMod, target, type, move) {
-				if (move && this.dex.getImmunity(move, type) === false) return 3;
+				if (move && this.dex.getImmunity(move, type) === false) return 1;
 				return typeMod * -1;
 			},
 		desc: "Holder's weaknesses and resistances (including immunities) are swapped like in an Inverse Battle.",
@@ -190,7 +190,11 @@ export const BattleItems: {[k: string]: ModdedItemData} = {
 		onStart: function(pokemon) {
 			this.add('-item', pokemon, 'Rage Candy Bar');
 			if (pokemon.species.baseSpecies === 'Darmanitan') {
-				pokemon.addVolatile('zenmode');
+				if (!pokemon.species.name.includes('Galar')) {
+					if (pokemon.species.id !== 'darmanitanzen') pokemon.formeChange('Darmanitan-Zen');
+				} else {
+					if (pokemon.species.id !== 'darmanitangalarzen') pokemon.formeChange('Darmanitan-Galar-Zen');
+				}
 			}
 		},
 		fling: {
@@ -198,7 +202,10 @@ export const BattleItems: {[k: string]: ModdedItemData} = {
 		},
 		onBasePowerPriority: 6,
 		onBasePower: function(basePower, user, target, move) {
-			if (move && (user.baseSpecies.num === 555) && (move.type === 'Psychic')) {
+			if (move && (user.species.id === 'darmanitanzen') && (move.type === 'Psychic')) {
+				return this.chainModify([0x1333, 0x1000]);
+			}
+			if (move && (user.species.id === 'darmanitangalarzen') && (move.type === 'Fire')) {
 				return this.chainModify([0x1333, 0x1000]);
 			}
 		},

--- a/data/mods/sylvemonstest/items.ts
+++ b/data/mods/sylvemonstest/items.ts
@@ -2,12 +2,6 @@ export const BattleItems: {[k: string]: ModdedItemData} = {
 	"safetysocks": {
 		id: "safetysocks",
 		name: "Safety Socks",
-		onDamage: function (damage, target, source, effect) {
-			let hazards = ["stealthrock", "stickyweb"];
-			if (effect.sideCondition !== 'Move') {
-				return false;
-			}
-		},
 		desc: "Holder is unaffected by Hazards.",
 	},
 	"reversecore": {
@@ -17,8 +11,9 @@ export const BattleItems: {[k: string]: ModdedItemData} = {
 			basePower: 30,
 		},
 		onTakeItem: false,
-		onStart(pokemon) {
-			this.add('-item', pokemon, pokemon.getItem());
+		onStart(target) {
+			this.add('-item', target, 'Reverse Core');
+			this.add('-message', `${target.name} is cloaked in a mysterious power!`);
 		},
 		onModifyMovePriority: -5,
 		onEffectiveness(typeMod, target, type, move) {
@@ -194,7 +189,7 @@ export const BattleItems: {[k: string]: ModdedItemData} = {
 		name: "Rage Candy Bar",
 		onStart: function(pokemon) {
 			this.add('-item', pokemon, 'Rage Candy Bar');
-			if (pokemon.baseSpecies.baseSpecies === 'Darmanitan') {
+			if (pokemon.species.baseSpecies === 'Darmanitan') {
 				pokemon.addVolatile('zenmode');
 			}
 		},

--- a/data/mods/sylvemonstest/moves.ts
+++ b/data/mods/sylvemonstest/moves.ts
@@ -39,7 +39,7 @@ export const BattleMovedex: {[k: string]: ModdedMoveData} = {
 			this.attrLastMove('[still]');
 			this.add('-anim', source, "Heavy Slam", target);
 		},
-		//useTargetOffensive: true,
+		useSourceDefensiveAsOffensive: true,
 		secondary: null,
 		target: "normal",
 		type: "Steel",
@@ -1756,7 +1756,7 @@ export const BattleMovedex: {[k: string]: ModdedMoveData} = {
 		zMovePower: 140,
 		contestType: "Tough",
 	},
-"wildcharge": {
+	"wildcharge": {
 		num: 528,
 		accuracy: 80,
 		basePower: 150,
@@ -1776,6 +1776,7 @@ export const BattleMovedex: {[k: string]: ModdedMoveData} = {
 		zMovePower: 200,
 		contestType: "Tough",
 	},
+
 	"stickyweb": {
 		inherit: true,
 		effect: {
@@ -1783,7 +1784,7 @@ export const BattleMovedex: {[k: string]: ModdedMoveData} = {
 				this.add('-sidestart', side, 'move: Sticky Web');
 			},
 			onSwitchIn: function (pokemon) {
-				if (!pokemon.isGrounded() || pokemon.hasItem('safetysocks') || pokemon.hasItem('heavydutyboots')) return;
+				if (!pokemon.isGrounded() || pokemon.hasItem('heavydutyboots') || pokemon.hasItem('safetysocks')) return;
 				this.add('-activate', pokemon, 'move: Sticky Web');
 				this.boost({spe: -1}, pokemon, this.effectData.source, this.dex.getActiveMove('stickyweb'))
 			},
@@ -1817,7 +1818,7 @@ export const BattleMovedex: {[k: string]: ModdedMoveData} = {
 				if (pokemon.hasType('Poison')) {
 					this.add('-sideend', pokemon.side, 'move: Toxic Spikes', '[of] ' + pokemon);
 					pokemon.side.removeSideCondition('toxicspikes');
-				} else if (pokemon.hasType('Steel') || pokemon.hasItem('heavydutyboots') || pokemon.hasItem('safetysocks') ) {
+				} else if (pokemon.hasType('Steel') || pokemon.hasItem('heavydutyboots') || pokemon.hasItem('safetysocks')) {
 					return;
 				} else if (this.effectData.layers >= 2) {
 					pokemon.trySetStatus('tox', pokemon.side.foe.active[0]);
@@ -1832,7 +1833,111 @@ export const BattleMovedex: {[k: string]: ModdedMoveData} = {
 		zMove: {boost: {def: 1}},
 		contestType: "Clever",
 	},
-"fairylock": {
+	gmaxsteelsurge: {
+		num: 1000,
+		accuracy: true,
+		basePower: 10,
+		category: "Physical",
+		desc: "Power is equal to the base move's Max Move power. If this move is successful, it sets up a hazard on the opposing side of the field, damaging each opposing Pokemon that switches in. Foes lose 1/32, 1/16, 1/8, 1/4, or 1/2 of their maximum HP, rounded down, based on their weakness to the Steel type; 0.25x, 0.5x, neutral, 2x, or 4x, respectively. Can be removed from the opposing side if any opposing Pokemon uses Rapid Spin or Defog successfully, or is hit by Defog.",
+		shortDesc: "Base move affects power. Foes: Steel hazard.",
+		name: "G-Max Steelsurge",
+		pp: 5,
+		priority: 0,
+		flags: {},
+		isMax: "Copperajah",
+		self: {
+			onHit(source) {
+				source.side.foe.addSideCondition('gmaxsteelsurge');
+			},
+		},
+		effect: {
+			onStart(side) {
+				this.add('-sidestart', side, 'move: G-Max Steelsurge');
+			},
+			onSwitchIn(pokemon) {
+				if (pokemon.hasItem('heavydutyboots') || pokemon.hasItem('safetysocks')) return;
+				// Ice Face and Disguise correctly get typed damage from Stealth Rock
+				// because Stealth Rock bypasses Substitute.
+				// They don't get typed damage from Steelsurge because Steelsurge doesn't,
+				// so we're going to test the damage of a Steel-type Stealth Rock instead.
+				const steelHazard = this.dex.getActiveMove('Stealth Rock');
+				steelHazard.type = 'Steel';
+				const typeMod = this.clampIntRange(pokemon.runEffectiveness(steelHazard), -6, 6);
+				this.damage(pokemon.maxhp * Math.pow(2, typeMod) / 8);
+			},
+		},
+		secondary: null,
+		target: "adjacentFoe",
+		type: "Steel",
+		contestType: "Cool",
+	},
+	spikes: {
+		num: 191,
+		accuracy: true,
+		basePower: 0,
+		category: "Status",
+		desc: "Sets up a hazard on the opposing side of the field, damaging each opposing Pokemon that switches in, unless it is a Flying-type Pokemon or has the Levitate Ability. Can be used up to three times before failing. Opponents lose 1/8 of their maximum HP with one layer, 1/6 of their maximum HP with two layers, and 1/4 of their maximum HP with three layers, all rounded down. Can be removed from the opposing side if any opposing Pokemon uses Rapid Spin or Defog successfully, or is hit by Defog.",
+		shortDesc: "Hurts grounded foes on switch-in. Max 3 layers.",
+		name: "Spikes",
+		pp: 20,
+		priority: 0,
+		flags: {reflectable: 1, nonsky: 1},
+		sideCondition: 'spikes',
+		effect: {
+			// this is a side condition
+			onStart(side) {
+				this.add('-sidestart', side, 'Spikes');
+				this.effectData.layers = 1;
+			},
+			onRestart(side) {
+				if (this.effectData.layers >= 3) return false;
+				this.add('-sidestart', side, 'Spikes');
+				this.effectData.layers++;
+			},
+			onSwitchIn(pokemon) {
+				if (!pokemon.isGrounded()) return;
+				if (pokemon.hasItem('heavydutyboots') || pokemon.hasItem('safetysocks')) return;
+				const damageAmounts = [0, 3, 4, 6]; // 1/8, 1/6, 1/4
+				this.damage(damageAmounts[this.effectData.layers] * pokemon.maxhp / 24);
+			},
+		},
+		secondary: null,
+		target: "foeSide",
+		type: "Ground",
+		zMove: {boost: {def: 1}},
+		contestType: "Clever",
+	},
+	stealthrock: {
+		num: 446,
+		accuracy: true,
+		basePower: 0,
+		category: "Status",
+		desc: "Sets up a hazard on the opposing side of the field, damaging each opposing Pokemon that switches in. Fails if the effect is already active on the opposing side. Foes lose 1/32, 1/16, 1/8, 1/4, or 1/2 of their maximum HP, rounded down, based on their weakness to the Rock type; 0.25x, 0.5x, neutral, 2x, or 4x, respectively. Can be removed from the opposing side if any opposing Pokemon uses Rapid Spin or Defog successfully, or is hit by Defog.",
+		shortDesc: "Hurts foes on switch-in. Factors Rock weakness.",
+		name: "Stealth Rock",
+		pp: 20,
+		priority: 0,
+		flags: {reflectable: 1},
+		sideCondition: 'stealthrock',
+		effect: {
+			// this is a side condition
+			onStart(side) {
+				this.add('-sidestart', side, 'move: Stealth Rock');
+			},
+			onSwitchIn(pokemon) {
+				if (pokemon.hasItem('heavydutyboots') || pokemon.hasItem('safetysocks')) return;
+				const typeMod = this.clampIntRange(pokemon.runEffectiveness(this.dex.getActiveMove('stealthrock')), -6, 6);
+				this.damage(pokemon.maxhp * Math.pow(2, typeMod) / 8);
+			},
+		},
+		secondary: null,
+		target: "foeSide",
+		type: "Rock",
+		zMove: {boost: {def: 1}},
+		contestType: "Cool",
+	},
+
+	"fairylock": {
 		num: 587,
 		accuracy: 100,
 		basePower: 80,

--- a/data/mods/sylvemonstest/moves.ts
+++ b/data/mods/sylvemonstest/moves.ts
@@ -78,7 +78,7 @@ export const BattleMovedex: {[k: string]: ModdedMoveData} = {
 				return null;
 			},
 			onEffectiveness: function(typeMod, target, type, move) {
-				if (move && !this.getImmunity(move, type)) return 1;
+				if (move && this.dex.getImmunity(move, type) === false) return 3;
 				return -typeMod;
 			},
 			onResidualOrder: 23,

--- a/data/mods/sylvemonstest/statuses.ts
+++ b/data/mods/sylvemonstest/statuses.ts
@@ -1,4 +1,29 @@
 export const BattleStatuses: {[k: string]: ModdedStatusData} = {
+
+	par: {
+		name: 'par',
+		effectType: 'Status',
+		onStart(target, source, sourceEffect) {
+			if (sourceEffect && sourceEffect.effectType === 'Ability') {
+				this.add('-status', target, 'par', '[from] ability: ' + sourceEffect.name, '[of] ' + source);
+			} else {
+				this.add('-status', target, 'par');
+			}
+		},
+		onModifySpe(spe, pokemon) {
+			if (!pokemon.hasAbility('quickfeet')) {
+				return this.chainModify(0.5);
+			}
+		},
+		onBeforeMovePriority: 1,
+		onBeforeMove(pokemon) {
+			if (pokemon.hasAbility('quickfeet')) return;
+			if (this.randomChance(1, 4)) {
+				this.add('cant', pokemon, 'par');
+				return false;
+			}
+		},
+	},
 	hail: {
 		effectType: 'Weather',
 		duration: 5,


### PR DESCRIPTION
Includes fixes for Inverse Room, Reverse Core, Mind Trick, Safety Socks, Shield Slam, Quick Feet, RageCandyBar, Dark Rising and Cursed Body
(Safety Socks and Shield Slam don't really count because I just copied from the Gen VIII effects that match them, but I helped with the rest, at least XP)