### PR TITLE
SylveMons bugfixes variety hour

### DIFF
--- a/data/mods/sylvemonstest/abilities.ts
+++ b/data/mods/sylvemonstest/abilities.ts
@@ -508,7 +508,8 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 	"angerpoint": {
 		shortDesc: "This Pokemon's Attack is raised by 1 stage after it is damaged by a move.",
 		onDamagingHit(damage, target, source, effect) {
-             this.boost({atk: 1});
+         if (source === target) return;     
+			this.boost({atk: 1});
 		},
 		id: "angerpoint",
 		name: "Anger Point",
@@ -518,6 +519,7 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 	"infuriation": {
 		shortDesc: "This Pokemon's Special Attack is raised by 1 stage after it is damaged by a move.",
 		onDamagingHit(damage, target, source, effect) {
+			if (source === target) return;  
 			this.boost({spa: 1});
 		},
 		id: "infuriation",
@@ -526,6 +528,7 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 	"perseverance": {
 		shortDesc: "This Pokemon's Special Defense is raised by 1 stage after it is damaged by a move.",
 		onDamagingHit(damage, target, source, effect) {
+			if (source === target) return;  
 			this.boost({spd: 1});
 		},
 		id: "perseverance",
@@ -534,6 +537,7 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 	"stalwart": {
 		shortDesc: "This Pokemon's Speed is raised by 1 stage after it is damaged by a move.",
 		onDamagingHit(damage, target, source, effect) {
+			if (source === target) return;  
 			this.boost({spe: 1});
 		},
 		id: "stalwart",
@@ -541,6 +545,13 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 		rating: 3,
 		num: 242,
 	},	    
+	stamina: { //added when fixing the synthesis bug, just as a failsafe
+		inherit: true, 
+		onDamagingHit(damage, target, source, effect) {
+			if (source === target) return;  
+			this.boost({def: 1});
+		},
+	},
 	"surgesurfer": {
 		shortDesc: "If a Terrain is active, this Pokemon's Speed is doubled.",
 		onModifySpe (spe) {

--- a/data/mods/sylvemonstest/abilities.ts
+++ b/data/mods/sylvemonstest/abilities.ts
@@ -173,7 +173,6 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 		shortDesc: "Summons Shadow Sky upon switching in.",
 		onStart(source) {
 			this.field.setWeather('shadowsky');
-			this.add('-ability', source, 'Shadow Surge');
 		},
 		id: "shadowsurge",
 		name: "Shadow Surge",
@@ -182,7 +181,6 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 		shortDesc: "Summons Air Current upon switching in.",
 		onStart(source) {
 			this.field.setWeather('aircurrent');
-			this.add('-ability', source, 'Air Stream');
 		},
 		id: "airstream",
 		name: "Air Stream",

--- a/data/mods/sylvemonstest/abilities.ts
+++ b/data/mods/sylvemonstest/abilities.ts
@@ -185,13 +185,32 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 		id: "airstream",
 		name: "Air Stream",
 	},
-	"timewarp": {
-		shortDesc: "On switch-in, this Pokemon summons Trick Room.",
+	timewarp: { //copied from hematite's version in smash mods melee, which was copied from his code from mfa! 
+		desc: "On switch-in, the field becomes Trick Room. This room remains in effect until this Ability is no longer active for any Pokémon.",
+		shortDesc: "On switch-in, Trick Room begins until this Ability is not active in battle.",
 		onStart(source) {
-			this.useMove("Trick Room", source);
+			this.field.removePseudoWeather('trickroom');
+			this.field.addPseudoWeather('trickroom');
 		},
-		id: "timewarp",
+		onAnyTryMove(target, source, effect) {
+			if (['trickroom'].includes(effect.id)) {
+				this.attrLastMove('[still]');
+				this.add('cant', this.effectData.target, 'ability: Time Warp', effect, '[of] ' + target);
+				return false;
+			}
+		},
+		onEnd(pokemon) {
+			for (const target of this.getAllActive()) {
+				if (target === pokemon) continue;
+				if (target.hasAbility('timewarp')) {
+					return;
+				}
+			}
+			this.field.removePseudoWeather('trickroom');
+		},
 		name: "Time Warp",
+		rating: 4.5,
+		num: -1004,
 	},
 	"dimensionwarp": {
 		shortDesc: "On switch-in, this Pokemon summons Inverse Room.",

--- a/data/mods/sylvemonstest/conditions.ts
+++ b/data/mods/sylvemonstest/conditions.ts
@@ -78,6 +78,7 @@ export const Conditions: {[k: string]: ConditionData} = {
 				if (this.gen <= 5) this.effectData.duration = 0;
 				this.add('-weather', 'AirCurrent', '[from] ability: ' + effect, '[of] ' + source);
 			} else {
+				this.add('-weather', 'none');
 				this.add('-weather', 'AirCurrent');
 			}
 		},
@@ -87,7 +88,7 @@ export const Conditions: {[k: string]: ConditionData} = {
 			this.eachEvent('Weather');
 		},
 		onEnd: function () {
-			this.add('raw|<h3>Air Current faded away</h3>');
+			this.add('-message', 'Air Current faded away.');
 		},
 	},
 	shadowsky: {
@@ -120,7 +121,8 @@ export const Conditions: {[k: string]: ConditionData} = {
 			this.eachEvent('Weather');
 		},
 		onEnd: function () {
-			this.add('raw|<h3>Shadow Sky faded away</h3>');
+			this.add('-weather', 'none');
+			this.add('-message', 'Shadow Sky faded away.');
 		},
 	},
   };

--- a/data/mods/sylvemonstest/moves.ts
+++ b/data/mods/sylvemonstest/moves.ts
@@ -1503,6 +1503,10 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				else if (source && source.hasItem('roomextender')) {
 					return 8;
 				}
+				if (source?.hasAbility('timewarp')) {
+					this.add('-activate', source, 'ability: Time Warp', effect);
+					return 0;
+				}
 				return 5;
 			},
 			onStart: function(target, source) {

--- a/data/mods/sylvemonstest/scripts.ts
+++ b/data/mods/sylvemonstest/scripts.ts
@@ -3761,7 +3761,7 @@ this.modData('Learnsets', 'abomasnow').learnset.iceball = ['7L1'];
 
     if (move.useTargetOffensive) {
       attack = defender.calculateStat(attackStat, atkBoosts);
-    } else if (move.id === "shieldslam") {
+    } else if (move.id === "shieldslam" || move.id === "bodypress") {
       attack = attacker.calculateStat("def", attacker.boosts.def);
     } else {
       attack = attacker.calculateStat(attackStat, atkBoosts);


### PR DESCRIPTION
**Bugfixes:** 
- Fixed Air Current and Shadow Sky not visually deactivating properly
- Fixed some activation messages to do with Air Current and Shadow Sky
- Fixed bug where Stamina-adjacent abilities counted Synthesis-adjacent moves as "damaging hits" for some reason 
- Fixed Body Press not calculating correctly (I think... the calc actually seems a bit off, uhm, I might need a second opinion on this one...? Either way it should be calculating the same as Shield Slam now at least!) 

**Additions:**
- Added code for the ability Time Warp, copied from Hematite's code for it from Smash Mods Melee