### PR TITLE
Crystal Sevii Islands - Gen 2 Substitute Bug

### DIFF
--- a/data/mods/gen2crystalseviiislands/moves.ts
+++ b/data/mods/gen2crystalseviiislands/moves.ts
@@ -797,6 +797,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		desc: "Sets up a hazard on the opposing side of the field, causing each opposing Pokemon that switches in to lose 1/8 of their maximum HP, rounded down, unless it is a Flying-type Pokemon. Fails if the effect is already active on the opposing side. Can be removed from the opposing side if any opposing Pokemon uses Rapid Spin successfully.",
 		shortDesc: "Hurts grounded foes on switch-in. Max 1 layer.",
+		flags: {authentic: 1, reflectable: 1, nonsky: 1},
 		effect: {
 			// this is a side condition
 			onStart(side) {

--- a/data/mods/gen2crystalseviiislands/moves.ts
+++ b/data/mods/gen2crystalseviiislands/moves.ts
@@ -922,10 +922,6 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				this.add('-miss', pokemon);
 				return null;
 			}
-			else {
-			let success = false;
-			if (!target.volatiles['substitute'] || move.infiltrates) success = !!this.boost({atk: 2});
-			}
 		},
 	},
 	sweetscent: {

--- a/data/mods/gen2crystalseviiislands/moves.ts
+++ b/data/mods/gen2crystalseviiislands/moves.ts
@@ -916,7 +916,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	},
 	swagger: {
 		inherit: true,
-		flags: {authentic: 1},
+		flags: {protect: 1, mirror: 1, authentic: 1, mystery: 1},
 		desc: "Raises the target's Attack by 2 stages and confuses it. This move will miss if the target's Attack cannot be raised.",
 		onTryHit(target, pokemon, move) {
 			if (target.boosts.atk >= 6 || target.getStat('atk', false, true) === 999) {

--- a/data/mods/gen2crystalseviiislands/moves.ts
+++ b/data/mods/gen2crystalseviiislands/moves.ts
@@ -923,10 +923,8 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				this.add('-miss', pokemon);
 				return null;
 			}
-		},
-		onHit(target){
 			if (target.volatiles['substitute']) return false;
-		}
+		},
 	},
 	sweetscent: {
 		inherit: true,

--- a/data/mods/gen2crystalseviiislands/moves.ts
+++ b/data/mods/gen2crystalseviiislands/moves.ts
@@ -840,10 +840,10 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	},
 	substitute: {
 		inherit: true,
-		condition: {
+		effect: {
 			onStart(target) {
 				this.add('-start', target, 'Substitute');
-				this.effectState.hp = Math.floor(target.maxhp / 4);
+				this.effectData.hp = Math.floor(target.maxhp / 4);
 				delete target.volatiles['partiallytrapped'];
 			},
 			onTryPrimaryHitPriority: -1,
@@ -879,7 +879,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 					}
 					return;
 				}
-				let damage = this.actions.getDamage(source, target, move);
+				let damage = this.getDamage(source, target, move);
 				if (!damage) {
 					return null;
 				}

--- a/data/mods/gen2crystalseviiislands/moves.ts
+++ b/data/mods/gen2crystalseviiislands/moves.ts
@@ -923,7 +923,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				this.add('-miss', pokemon);
 				return null;
 			}
-			if (target.volatiles['substitute']) return false;
+			if (target.volatiles['substitute']) delete move.volatileStatus;;
 		},
 	},
 	sweetscent: {

--- a/data/mods/gen2crystalseviiislands/moves.ts
+++ b/data/mods/gen2crystalseviiislands/moves.ts
@@ -917,11 +917,12 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	swagger: {
 		inherit: true,
 		desc: "Raises the target's Attack by 2 stages and confuses it. This move will miss if the target's Attack cannot be raised.",
-		flags: {authentic: 1},
 		onTryHit(target, pokemon) {
 			if (target.boosts.atk >= 6 || target.getStat('atk', false, true) === 999) {
 				this.add('-miss', pokemon);
 				return null;
+			} else {
+				if (!target.volatiles['substitute'] || move.infiltrates) success = !!this.boost({atk: 2});
 			}
 		},
 	},

--- a/data/mods/gen2crystalseviiislands/moves.ts
+++ b/data/mods/gen2crystalseviiislands/moves.ts
@@ -922,13 +922,13 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				this.add('-miss', pokemon);
 				return null;
 			}
-		},
-		onHit(target, source, move) {
-			let success = false;
+			else {
+				let success = false;
 			for (const pokemon of source.side.foe.active) {
 				if (!target.volatiles['substitute'] || move.infiltrates) success = !!this.boost({atk: 2});
 				}
 			return success;
+			}
 		},
 	},
 	sweetscent: {

--- a/data/mods/gen2crystalseviiislands/moves.ts
+++ b/data/mods/gen2crystalseviiislands/moves.ts
@@ -813,7 +813,6 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				this.damage(damageAmounts[this.effectData.layers] * pokemon.maxhp / 24);
 			},
 		},
-		target: "foeSide",
 	},
 	spite: {
 		inherit: true,
@@ -867,7 +866,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				}
 				if (move.category === 'Status') {
 					const SubBlocked = ['leechseed', 'lockon', 'mindreader', 'nightmare', 'painsplit', 'sketch'];
-					if (move.id === 'swagger') {
+					if (move.id === 'swagger' || 'spikes') {
 						// this is safe, move is a copy
 						delete move.volatileStatus;
 					}

--- a/data/mods/gen2crystalseviiislands/moves.ts
+++ b/data/mods/gen2crystalseviiislands/moves.ts
@@ -917,14 +917,14 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	swagger: {
 		inherit: true,
 		desc: "Raises the target's Attack by 2 stages and confuses it. This move will miss if the target's Attack cannot be raised.",
-		onTryHit(target, pokemon) {
+		onTryHit(target, pokemon, move) {
 			if (target.boosts.atk >= 6 || target.getStat('atk', false, true) === 999) {
 				this.add('-miss', pokemon);
 				return null;
 			}
 			else {
 				let success = false;
-			for (const pokemon of source.side.foe.active) {
+			for (const target) {
 				if (!target.volatiles['substitute'] || move.infiltrates) success = !!this.boost({atk: 2});
 				}
 			return success;

--- a/data/mods/gen2crystalseviiislands/moves.ts
+++ b/data/mods/gen2crystalseviiislands/moves.ts
@@ -797,7 +797,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		desc: "Sets up a hazard on the opposing side of the field, causing each opposing Pokemon that switches in to lose 1/8 of their maximum HP, rounded down, unless it is a Flying-type Pokemon. Fails if the effect is already active on the opposing side. Can be removed from the opposing side if any opposing Pokemon uses Rapid Spin successfully.",
 		shortDesc: "Hurts grounded foes on switch-in. Max 1 layer.",
-		effect: {
+		condition: {
 			// this is a side condition
 			onSideStart(side) {
 				if (!this.effectState.layers || this.effectState.layers === 0) {
@@ -840,7 +840,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	},
 	substitute: {
 		inherit: true,
-		effect: {
+		condition: {
 			onStart(target) {
 				this.add('-start', target, 'Substitute');
 				this.effectState.hp = Math.floor(target.maxhp / 4);

--- a/data/mods/gen2crystalseviiislands/moves.ts
+++ b/data/mods/gen2crystalseviiislands/moves.ts
@@ -923,7 +923,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				this.add('-miss', pokemon);
 				return null;
 			}
-			if (target.volatiles['substitute']) delete move.volatileStatus;;
+			if (target.volatiles['substitute']) delete move.volatileStatus;
 		},
 	},
 	sweetscent: {

--- a/data/mods/gen2crystalseviiislands/moves.ts
+++ b/data/mods/gen2crystalseviiislands/moves.ts
@@ -797,12 +797,12 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		desc: "Sets up a hazard on the opposing side of the field, causing each opposing Pokemon that switches in to lose 1/8 of their maximum HP, rounded down, unless it is a Flying-type Pokemon. Fails if the effect is already active on the opposing side. Can be removed from the opposing side if any opposing Pokemon uses Rapid Spin successfully.",
 		shortDesc: "Hurts grounded foes on switch-in. Max 1 layer.",
-		condition: {
+		effect: {
 			// this is a side condition
-			onSideStart(side) {
-				if (!this.effectState.layers || this.effectState.layers === 0) {
+			onStart(side) {
+				if (!this.effectData.layers || this.effectData.layers === 0) {
 					this.add('-sidestart', side, 'Spikes');
-					this.effectState.layers = 1;
+					this.effectData.layers = 1;
 				} else {
 					return false;
 				}
@@ -810,9 +810,10 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			onSwitchIn(pokemon) {
 				if (!pokemon.runImmunity('Ground')) return;
 				const damageAmounts = [0, 3];
-				this.damage(damageAmounts[this.effectState.layers] * pokemon.maxhp / 24);
+				this.damage(damageAmounts[this.effectData.layers] * pokemon.maxhp / 24);
 			},
 		},
+		target: "foeSide",
 	},
 	spite: {
 		inherit: true,

--- a/data/mods/gen2crystalseviiislands/moves.ts
+++ b/data/mods/gen2crystalseviiislands/moves.ts
@@ -925,9 +925,8 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		},
 		onHit(target, source, move) {
 			let success = false;
-			for (const target of source.side.pokemon) {
-				if (target.volatiles['substitute'] && !move.infiltrates))) {
-					continue;
+			for (const pokemon of source.side.foe.active) {
+				if (!target.volatiles['substitute'] || move.infiltrates) success = !!this.boost({atk: 2});
 				}
 			return success;
 		},

--- a/data/mods/gen2crystalseviiislands/moves.ts
+++ b/data/mods/gen2crystalseviiislands/moves.ts
@@ -866,7 +866,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				}
 				if (move.category === 'Status') {
 					const SubBlocked = ['leechseed', 'lockon', 'mindreader', 'nightmare', 'painsplit', 'sketch'];
-					if (move.id === 'swagger' || 'spikes') {
+					if (move.id === 'swagger') {
 						// this is safe, move is a copy
 						delete move.volatileStatus;
 					}

--- a/data/mods/gen2crystalseviiislands/moves.ts
+++ b/data/mods/gen2crystalseviiislands/moves.ts
@@ -923,9 +923,13 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				return null;
 			}
 		},
-		onHit(target, pokemon, move) {
+		onHit(pokemon, source, move) {
 			let success = false;
-			if (!target.volatiles['substitute'] || move.infiltrates) success = !!this.boost({atk: 2});
+			for (const pokemon of source.side.pokemon) {
+				if (pokemon.volatiles['substitute'] && !move.infiltrates))) {
+					continue;
+				}
+			return success;
 		},
 	},
 	sweetscent: {

--- a/data/mods/gen2crystalseviiislands/moves.ts
+++ b/data/mods/gen2crystalseviiislands/moves.ts
@@ -921,9 +921,11 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			if (target.boosts.atk >= 6 || target.getStat('atk', false, true) === 999) {
 				this.add('-miss', pokemon);
 				return null;
-			} else {
-				if (!target.volatiles['substitute'] || move.infiltrates) success = !!this.boost({atk: 2});
 			}
+		},
+		onHit(target, source, move) {
+			let success = false;
+			if (!target.volatiles['substitute'] || move.infiltrates) success = !!this.boost({atk: 2});
 		},
 	},
 	sweetscent: {

--- a/data/mods/gen2crystalseviiislands/moves.ts
+++ b/data/mods/gen2crystalseviiislands/moves.ts
@@ -799,10 +799,10 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		shortDesc: "Hurts grounded foes on switch-in. Max 1 layer.",
 		effect: {
 			// this is a side condition
-			onStart(side) {
-				if (!this.effectData.layers || this.effectData.layers === 0) {
+			onSideStart(side) {
+				if (!this.effectState.layers || this.effectState.layers === 0) {
 					this.add('-sidestart', side, 'Spikes');
-					this.effectData.layers = 1;
+					this.effectState.layers = 1;
 				} else {
 					return false;
 				}
@@ -810,7 +810,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			onSwitchIn(pokemon) {
 				if (!pokemon.runImmunity('Ground')) return;
 				const damageAmounts = [0, 3];
-				this.damage(damageAmounts[this.effectData.layers] * pokemon.maxhp / 24);
+				this.damage(damageAmounts[this.effectState.layers] * pokemon.maxhp / 24);
 			},
 		},
 	},
@@ -843,7 +843,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		effect: {
 			onStart(target) {
 				this.add('-start', target, 'Substitute');
-				this.effectData.hp = Math.floor(target.maxhp / 4);
+				this.effectState.hp = Math.floor(target.maxhp / 4);
 				delete target.volatiles['partiallytrapped'];
 			},
 			onTryPrimaryHitPriority: -1,
@@ -879,7 +879,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 					}
 					return;
 				}
-				let damage = this.getDamage(source, target, move);
+				let damage = this.actions.getDamage(source, target, move);
 				if (!damage) {
 					return null;
 				}

--- a/data/mods/gen2crystalseviiislands/moves.ts
+++ b/data/mods/gen2crystalseviiislands/moves.ts
@@ -917,6 +917,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	swagger: {
 		inherit: true,
 		desc: "Raises the target's Attack by 2 stages and confuses it. This move will miss if the target's Attack cannot be raised.",
+		flags: {authentic: 1},
 		onTryHit(target, pokemon) {
 			if (target.boosts.atk >= 6 || target.getStat('atk', false, true) === 999) {
 				this.add('-miss', pokemon);

--- a/data/mods/gen2crystalseviiislands/moves.ts
+++ b/data/mods/gen2crystalseviiislands/moves.ts
@@ -916,11 +916,15 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	},
 	swagger: {
 		inherit: true,
+		flags: {authentic: 1},
 		desc: "Raises the target's Attack by 2 stages and confuses it. This move will miss if the target's Attack cannot be raised.",
 		onTryHit(target, pokemon, move) {
 			if (target.boosts.atk >= 6 || target.getStat('atk', false, true) === 999) {
 				this.add('-miss', pokemon);
 				return null;
+			}
+			else {
+				if (target.volatiles['substitute']) return false;
 			}
 		},
 	},

--- a/data/mods/gen2crystalseviiislands/moves.ts
+++ b/data/mods/gen2crystalseviiislands/moves.ts
@@ -923,7 +923,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				return null;
 			}
 		},
-		onHit(target, source, move) {
+		onHit(target, pokemon, move) {
 			let success = false;
 			if (!target.volatiles['substitute'] || move.infiltrates) success = !!this.boost({atk: 2});
 		},

--- a/data/mods/gen2crystalseviiislands/moves.ts
+++ b/data/mods/gen2crystalseviiislands/moves.ts
@@ -918,13 +918,14 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		desc: "Raises the target's Attack by 2 stages and confuses it. This move will miss if the target's Attack cannot be raised.",
 		onTryHit(target, pokemon, move) {
+			const targets = [];
 			if (target.boosts.atk >= 6 || target.getStat('atk', false, true) === 999) {
 				this.add('-miss', pokemon);
 				return null;
 			}
 			else {
 				let success = false;
-			for (const target) {
+			for (const target of targets) { {
 				if (!target.volatiles['substitute'] || move.infiltrates) success = !!this.boost({atk: 2});
 				}
 			return success;

--- a/data/mods/gen2crystalseviiislands/moves.ts
+++ b/data/mods/gen2crystalseviiislands/moves.ts
@@ -923,10 +923,10 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				this.add('-miss', pokemon);
 				return null;
 			}
-			else {
-				if (target.volatiles['substitute']) return false;
-			}
 		},
+		onHit(target){
+			if (target.volatiles['substitute']) return false;
+		}
 	},
 	sweetscent: {
 		inherit: true,

--- a/data/mods/gen2crystalseviiislands/moves.ts
+++ b/data/mods/gen2crystalseviiislands/moves.ts
@@ -923,10 +923,10 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				return null;
 			}
 		},
-		onHit(pokemon, source, move) {
+		onHit(target, source, move) {
 			let success = false;
-			for (const pokemon of source.side.pokemon) {
-				if (pokemon.volatiles['substitute'] && !move.infiltrates))) {
+			for (const target of source.side.pokemon) {
+				if (target.volatiles['substitute'] && !move.infiltrates))) {
 					continue;
 				}
 			return success;

--- a/data/mods/gen2crystalseviiislands/moves.ts
+++ b/data/mods/gen2crystalseviiislands/moves.ts
@@ -918,17 +918,13 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		desc: "Raises the target's Attack by 2 stages and confuses it. This move will miss if the target's Attack cannot be raised.",
 		onTryHit(target, pokemon, move) {
-			const targets = [];
 			if (target.boosts.atk >= 6 || target.getStat('atk', false, true) === 999) {
 				this.add('-miss', pokemon);
 				return null;
 			}
 			else {
-				let success = false;
-			for (const target of targets) { {
-				if (!target.volatiles['substitute'] || move.infiltrates) success = !!this.boost({atk: 2});
-				}
-			return success;
+			let success = false;
+			if (!target.volatiles['substitute'] || move.infiltrates) success = !!this.boost({atk: 2});
 			}
 		},
 	},

--- a/data/mods/gen2crystalseviiislands/moves.ts
+++ b/data/mods/gen2crystalseviiislands/moves.ts
@@ -797,7 +797,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		desc: "Sets up a hazard on the opposing side of the field, causing each opposing Pokemon that switches in to lose 1/8 of their maximum HP, rounded down, unless it is a Flying-type Pokemon. Fails if the effect is already active on the opposing side. Can be removed from the opposing side if any opposing Pokemon uses Rapid Spin successfully.",
 		shortDesc: "Hurts grounded foes on switch-in. Max 1 layer.",
-		flags: {authentic: 1, reflectable: 1, nonsky: 1},
+		flags: {authentic: 1},
 		effect: {
 			// this is a side condition
 			onStart(side) {


### PR DESCRIPTION
While testing CSI, we found out that Substitute is working incorrectly for Gen 2 OU (and probably all Gen 2 based formats) on DH.
Essentially on DH:
- Spikes failed when used on a Substitute
- Swagger failed when used on a Substitute (In Gen 2, Swagger partially bypasses Substitute - It just doesn't inflict the confusion status)

_*These moves work correctly on base Pokemon Showdown_.