### PR TITLE
Gen 2 Doubles and Earth & Sky

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -3492,10 +3492,10 @@ export const Formats: FormatList = [
 	// Past Generations
 	///////////////////////////////////////////////////////////////////
 
-	{
+	/*{
 		section: "Past Generations",
 		column: 4,
-	},
+	},*/
 	{
 		name: "[Gen 3] Ubers",
 		threads: [
@@ -3556,7 +3556,8 @@ export const Formats: FormatList = [
 
 		mod: 'gen3',
 		gameType: 'doubles',
-		//searchShow: false,
+		searchShow: false,
+		challengeShow: false,
 		debug: true,
 		ruleset: ['HP Percentage Mod', 'Cancel Mod'],
 	},

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -3489,6 +3489,173 @@ export const Formats: FormatList = [
 		ruleset: ['Standard Doubles', 'Swagger Clause'],
 		banlist: ['DUber', 'Power Construct', 'Eevium Z', 'Dark Void'],
 	},
+	// Past Generations
+	///////////////////////////////////////////////////////////////////
+
+	{
+		section: "Past Generations",
+		column: 4,
+	},
+	{
+		name: "[Gen 3] Ubers",
+		threads: [
+			`&bullet; <a href="https://www.smogon.com/forums/posts/8286280/">ADV Ubers</a>`,
+		],
+
+		mod: 'gen3',
+		searchShow: false,
+		challengeShow: false,
+		ruleset: ['Standard'],
+		banlist: ['Wobbuffet + Leftovers'],
+	},
+	{
+		name: "[Gen 3] UU",
+		threads: [
+			`&bullet; <a href="https://www.smogon.com/forums/threads/3585923/">ADV UU Metagame Discussion</a>`,
+			`&bullet; <a href="https://www.smogon.com/forums/threads/3548578/">ADV UU Viability Rankings</a>`,
+		],
+
+		mod: 'gen3',
+		searchShow: false,
+		challengeShow: false,
+		ruleset: ['Standard', 'NFE Clause'],
+		banlist: ['Uber', 'OU', 'UUBL', 'Smeargle + Ingrain'],
+		unbanlist: ['Scyther'],
+	},
+	{
+		name: "[Gen 3] 1v1",
+		desc: `Bring three Pok&eacute;mon to Team Preview and choose one to battle.`,
+		threads: [
+			`&bullet; <a href="https://www.smogon.com/forums/posts/8031456/">ADV 1v1</a>`,
+		],
+
+		mod: 'gen3',
+		searchShow: false,
+		challengeShow: false,
+		teamLength: {
+			validate: [1, 3],
+			battle: 1,
+		},
+		ruleset: ['[Gen 3] OU', 'Accuracy Moves Clause', 'Sleep Moves Clause', 'Team Preview'],
+		banlist: ['Slaking', 'Snorlax', 'Suicune', 'Destiny Bond', 'Explosion', 'Ingrain', 'Perish Song', 'Self-Destruct'],
+	},
+	{
+		name: "[Gen 3] Custom Game",
+
+		mod: 'gen3',
+		searchShow: false,
+		challengeShow: false,
+		debug: true,
+		maxLevel: 9999,
+		battle: {trunc: Math.trunc},
+		defaultLevel: 100,
+		ruleset: ['HP Percentage Mod', 'Cancel Mod'],
+	},
+	{
+		name: "[Gen 3] Doubles Custom Game",
+
+		mod: 'gen3',
+		gameType: 'doubles',
+		//searchShow: false,
+		debug: true,
+		ruleset: ['HP Percentage Mod', 'Cancel Mod'],
+	},
+	{
+		name: "[Gen 2] Ubers",
+		threads: [
+			`&bullet; <a href="https://www.smogon.com/forums/posts/8286282/">GSC Ubers</a>`,
+		],
+
+		mod: 'gen2',
+		searchShow: false,
+		challengeShow: false,
+		ruleset: ['Standard'],
+	},
+	{
+		name: "[Gen 2] UU",
+		threads: [`&bullet; <a href="https://www.smogon.com/forums/threads/3576710/">GSC UU</a>`],
+
+		mod: 'gen2',
+		searchShow: false,
+		challengeShow: false,
+		ruleset: ['[Gen 2] OU'],
+		banlist: ['OU', 'UUBL'],
+	},
+	{
+		name: "[Gen 2] NU",
+		threads: [`&bullet; <a href="https://www.smogon.com/forums/threads/3642565/">GSC NU</a>`],
+
+		mod: 'gen2',
+		searchShow: false,
+		challengeShow: false,
+		ruleset: ['[Gen 2] UU'],
+		banlist: ['UU', 'NUBL'],
+	},
+	{
+		name: "[Gen 2] Custom Game",
+
+		mod: 'gen2',
+		searchShow: false,
+		challengeShow: false,
+		debug: true,
+		maxLevel: 9999,
+		battle: {trunc: Math.trunc},
+		defaultLevel: 100,
+		ruleset: ['HP Percentage Mod', 'Cancel Mod'],
+	},
+	{
+		name: "[Gen 1] UU",
+		threads: [
+			`&bullet; <a href="https://www.smogon.com/forums/threads/3573896/">RBY UU Metagame Discussion</a>`,
+			`&bullet; <a href="https://www.smogon.com/forums/threads/3647713/">RBY UU Viability Rankings</a>`,
+		],
+
+		mod: 'gen1',
+		searchShow: false,
+		challengeShow: false,
+		ruleset: ['[Gen 1] OU'],
+		banlist: ['OU', 'UUBL'],
+	},
+	{
+		name: "[Gen 1] OU (Tradeback)",
+		desc: `RBY OU with movepool additions from the Time Capsule.`,
+		threads: [
+			`&bullet; <a href="https://www.smogon.com/articles/rby-tradebacks-ou">RBY Tradebacks OU</a>`,
+		],
+
+		mod: 'gen1',
+		searchShow: false,
+		challengeShow: false,
+		ruleset: ['Obtainable', 'Allow Tradeback', 'Sleep Clause Mod', 'Freeze Clause Mod', 'Species Clause', 'OHKO Clause', 'Evasion Moves Clause', 'HP Percentage Mod', 'Cancel Mod'],
+		banlist: ['Uber',
+			'Nidoking + Fury Attack + Thrash', 'Exeggutor + Poison Powder + Stomp', 'Exeggutor + Sleep Powder + Stomp',
+			'Exeggutor + Stun Spore + Stomp', 'Jolteon + Focus Energy + Thunder Shock', 'Flareon + Focus Energy + Ember',
+		],
+	},
+	{
+		name: "[Gen 1] Stadium OU",
+
+		mod: 'stadium',
+		searchShow: false,
+		challengeShow: false,
+		ruleset: ['Standard', 'Team Preview', '!Sleep Clause Mod', 'Stadium Sleep Clause'],
+		banlist: ['Uber',
+			'Nidoking + Fury Attack + Thrash', 'Exeggutor + Poison Powder + Stomp', 'Exeggutor + Sleep Powder + Stomp',
+			'Exeggutor + Stun Spore + Stomp', 'Jolteon + Focus Energy + Thunder Shock', 'Flareon + Focus Energy + Ember',
+		],
+	},
+	{
+		name: "[Gen 1] Custom Game",
+
+		mod: 'gen1',
+		searchShow: false,
+		challengeShow: false,
+		debug: true,
+		maxLevel: 9999,
+		battle: {trunc: Math.trunc},
+		defaultLevel: 100,
+		ruleset: ['HP Percentage Mod', 'Cancel Mod'],
+	},
 	{
 		section: "Super Secret Tour Formats",
 		column: 4,

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -3497,7 +3497,7 @@ export const Formats: FormatList = [
 		column: 4,
 	},*/
 	{
-		name: "[Gen 3] Ubers",
+		name: "[Gen 3] Ubers Custom Game",
 		threads: [
 			`&bullet; <a href="https://www.smogon.com/forums/posts/8286280/">ADV Ubers</a>`,
 		],
@@ -3509,7 +3509,7 @@ export const Formats: FormatList = [
 		banlist: ['Wobbuffet + Leftovers'],
 	},
 	{
-		name: "[Gen 3] UU",
+		name: "[Gen 3] UU Custom Game",
 		threads: [
 			`&bullet; <a href="https://www.smogon.com/forums/threads/3585923/">ADV UU Metagame Discussion</a>`,
 			`&bullet; <a href="https://www.smogon.com/forums/threads/3548578/">ADV UU Viability Rankings</a>`,
@@ -3523,7 +3523,7 @@ export const Formats: FormatList = [
 		unbanlist: ['Scyther'],
 	},
 	{
-		name: "[Gen 3] 1v1",
+		name: "[Gen 3] 1v1 Custom Game",
 		desc: `Bring three Pok&eacute;mon to Team Preview and choose one to battle.`,
 		threads: [
 			`&bullet; <a href="https://www.smogon.com/forums/posts/8031456/">ADV 1v1</a>`,
@@ -3562,7 +3562,7 @@ export const Formats: FormatList = [
 		ruleset: ['HP Percentage Mod', 'Cancel Mod'],
 	},
 	{
-		name: "[Gen 2] Ubers",
+		name: "[Gen 2] Ubers Custom Game",
 		threads: [
 			`&bullet; <a href="https://www.smogon.com/forums/posts/8286282/">GSC Ubers</a>`,
 		],
@@ -3573,7 +3573,7 @@ export const Formats: FormatList = [
 		ruleset: ['Standard'],
 	},
 	{
-		name: "[Gen 2] UU",
+		name: "[Gen 2] UU Custom Game",
 		threads: [`&bullet; <a href="https://www.smogon.com/forums/threads/3576710/">GSC UU</a>`],
 
 		mod: 'gen2',
@@ -3583,7 +3583,7 @@ export const Formats: FormatList = [
 		banlist: ['OU', 'UUBL'],
 	},
 	{
-		name: "[Gen 2] NU",
+		name: "[Gen 2] NU Custom Game",
 		threads: [`&bullet; <a href="https://www.smogon.com/forums/threads/3642565/">GSC NU</a>`],
 
 		mod: 'gen2',
@@ -3605,7 +3605,7 @@ export const Formats: FormatList = [
 		ruleset: ['HP Percentage Mod', 'Cancel Mod'],
 	},
 	{
-		name: "[Gen 1] UU",
+		name: "[Gen 1] UU Custom Game",
 		threads: [
 			`&bullet; <a href="https://www.smogon.com/forums/threads/3573896/">RBY UU Metagame Discussion</a>`,
 			`&bullet; <a href="https://www.smogon.com/forums/threads/3647713/">RBY UU Viability Rankings</a>`,
@@ -3618,7 +3618,7 @@ export const Formats: FormatList = [
 		banlist: ['OU', 'UUBL'],
 	},
 	{
-		name: "[Gen 1] OU (Tradeback)",
+		name: "[Gen 1] OU (Tradeback) Custom Game",
 		desc: `RBY OU with movepool additions from the Time Capsule.`,
 		threads: [
 			`&bullet; <a href="https://www.smogon.com/articles/rby-tradebacks-ou">RBY Tradebacks OU</a>`,
@@ -3634,7 +3634,7 @@ export const Formats: FormatList = [
 		],
 	},
 	{
-		name: "[Gen 1] Stadium OU",
+		name: "[Gen 1] Stadium OU Custom Game",
 
 		mod: 'stadium',
 		searchShow: false,

--- a/data/mods/earthsky/scripts.ts
+++ b/data/mods/earthsky/scripts.ts
@@ -5,6 +5,7 @@
 	export type Other = "Unreleased" | "Illegal" | "ES Uber" | "ES OU" | "ES NFE" | "ES LC" | "CAP" | "CAP NFE" | "CAP LC";
 };*/
 import {Pokemon} from '../../../sim/pokemon';
+import {Battle} from '../../../sim/battle';
 
 export const Scripts: ModdedBattleScriptsData = {
 	teambuilderConfig: {

--- a/data/mods/earthsky/scripts.ts
+++ b/data/mods/earthsky/scripts.ts
@@ -4,7 +4,7 @@
 	export type Doubles = "DUber" | "(DUber)" | "DOU" | "(DOU)" | "DBL" | "DUU" | "(DUU)" | "NFE" | "LC Uber" | "LC";
 	export type Other = "Unreleased" | "Illegal" | "ES Uber" | "ES OU" | "ES NFE" | "ES LC" | "CAP" | "CAP NFE" | "CAP LC";
 };*/
-import type {Pokemon} from '../../../sim/pokemon';
+import {Pokemon} from '../../../sim/pokemon';
 
 export const Scripts: ModdedBattleScriptsData = {
 	teambuilderConfig: {
@@ -530,7 +530,7 @@ export const Scripts: ModdedBattleScriptsData = {
 			// ...but 16-bit truncation happens even later, and can truncate to 0
 			return tr(baseDamage, 16);
 		},
-		/*singleEvent( //Can't be edited here, this documents what it has been changed to
+		singleEvent( //Can't be edited here, this documents what it has been changed to
 			eventid: string, effect: Effect, effectData: AnyObject | null,
 			target: string | Pokemon | Side | Field | Battle | null, source?: string | Pokemon | Effect | false | null,
 			sourceEffect?: Effect | string | null, relayVar?: any
@@ -610,8 +610,8 @@ export const Scripts: ModdedBattleScriptsData = {
 			this.event = parentEvent;
 
 			return returnVal === undefined ? relayVar : returnVal;
-		},*/
-		/*runEvent( //Same here
+		},
+		runEvent( //Same here
 			eventid: string, target?: Pokemon | Pokemon[] | Side | Battle | null, source?: string | Pokemon | false | null,
 			sourceEffect?: Effect | null, relayVar?: any, onEffect?: boolean, fastExit?: boolean
 		) {
@@ -786,7 +786,7 @@ export const Scripts: ModdedBattleScriptsData = {
 			this.event = parentEvent;
 
 			return Array.isArray(target) ? targetRelayVars : relayVar;
-		},*/
+		},
 		residualEvent(eventid: string, relayVar?: any) { //Stasis
 			let stasisMons: Pokemon[] = [];
 			const callbackName = `on${eventid}`;

--- a/data/mods/gen2doubles/moves.ts
+++ b/data/mods/gen2doubles/moves.ts
@@ -475,7 +475,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	},
 	lightscreen: {
 		inherit: true,
-		desc: "For 5 turns, the user and its party members have their Special Defense doubled. Critical hits ignore this effect. Fails if the effect is already active on the user's side.",
+		desc: "For 5 turns, the user and its party members have their Special Defense doubled, or 1.5x if there are multiple active Pokemon on the user's side. Critical hits ignore this effect. Fails if the effect is already active on the user's side.",
 		shortDesc: "For 5 turns, the user's party has doubled Sp. Def.",
 		effect: {
 			duration: 5,

--- a/data/mods/gen2doubles/scripts.ts
+++ b/data/mods/gen2doubles/scripts.ts
@@ -660,8 +660,8 @@ export const Scripts: ModdedBattleScriptsData = {
 		//MOD: Spread damage. Putting it here because it happens before weather in Gen III.
 		if (move.spreadHit && move.target === 'allAdjacentFoes') {
 			const spreadModifier = move.spreadModifier || 0.5;
-			this.battle.debug('Spread modifier: ' + spreadModifier);
-			damage = this.battle.modify(damage, spreadModifier);
+			this.debug('Spread modifier: ' + spreadModifier);
+			damage = this.modify(damage, spreadModifier);
 		}
 
 		// Weather modifiers

--- a/data/mods/gen2doubles/scripts.ts
+++ b/data/mods/gen2doubles/scripts.ts
@@ -49,7 +49,7 @@ export const Scripts: ModdedBattleScriptsData = {
 					(statName === 'def' && this.side.sideConditions['reflect']) ||
 					(statName === 'spd' && this.side.sideConditions['lightscreen'])
 				) {
-					stat *= (this.side.active.length > 1) ? 1.5 : 2;
+					stat *= (this.side.active.filter(active => active && !active.fainted).length > 1) ? 1.5 : 2;
 				}
 			}
 

--- a/data/mods/gen2doubles/scripts.ts
+++ b/data/mods/gen2doubles/scripts.ts
@@ -49,7 +49,7 @@ export const Scripts: ModdedBattleScriptsData = {
 					(statName === 'def' && this.side.sideConditions['reflect']) ||
 					(statName === 'spd' && this.side.sideConditions['lightscreen'])
 				) {
-					stat *= 2;
+					stat *= (this.side.active.length > 1) ? 1.5 : 2;
 				}
 			}
 
@@ -656,6 +656,13 @@ export const Scripts: ModdedBattleScriptsData = {
 		damage = Math.floor(damage / defense);
 		damage = this.clampIntRange(Math.floor(damage / 50), 1, 997);
 		damage += 2;
+		
+		//MOD: Spread damage. Putting it here because it happens before weather in Gen III.
+		if (move.spreadHit && move.target === 'allAdjacentFoes') {
+			const spreadModifier = move.spreadModifier || 0.5;
+			this.battle.debug('Spread modifier: ' + spreadModifier);
+			damage = this.battle.modify(damage, spreadModifier);
+		}
 
 		// Weather modifiers
 		if ((this.field.isWeather('raindance') && type === 'Water') || (this.field.isWeather('sunnyday') && type === 'Fire')) {

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -465,11 +465,6 @@ export class Battle {
 			this.debug(eventid + ' handler suppressed by Air Lock');
 			return relayVar;
 		}
-		/*if ((effect.effectType === 'Terrain' || eventid === 'Terrain') &&
-			eventid !== 'Residual' && eventid !== 'End' && this.field.suppressingTerrain()) {
-			this.debug(eventid + ' handler suppressed by Midnight');
-			return relayVar;
-		}*/
 
 		// @ts-ignore - dynamic lookup
 		const callback = effect[`on${eventid}`];
@@ -735,11 +730,6 @@ export class Battle {
 				this.debug(eventid + ' handler suppressed by Air Lock');
 				continue;
 			}
-			/*if ((effect.effectType === 'Terrain' || eventid === 'Terrain') &&
-				eventid !== 'Residual' && eventid !== 'End' && this.field.suppressingTerrain()) {
-				this.debug(eventid + ' handler suppressed by Midnight');
-				continue;
-			}*/
 			let returnVal;
 			if (typeof handler.callback === 'function') {
 				const parentEffect = this.effect;

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -465,11 +465,11 @@ export class Battle {
 			this.debug(eventid + ' handler suppressed by Air Lock');
 			return relayVar;
 		}
-		if ((effect.effectType === 'Terrain' || eventid === 'Terrain') &&
+		/*if ((effect.effectType === 'Terrain' || eventid === 'Terrain') &&
 			eventid !== 'Residual' && eventid !== 'End' && this.field.suppressingTerrain()) {
 			this.debug(eventid + ' handler suppressed by Midnight');
 			return relayVar;
-		}
+		}*/
 
 		// @ts-ignore - dynamic lookup
 		const callback = effect[`on${eventid}`];
@@ -735,11 +735,11 @@ export class Battle {
 				this.debug(eventid + ' handler suppressed by Air Lock');
 				continue;
 			}
-			if ((effect.effectType === 'Terrain' || eventid === 'Terrain') &&
+			/*if ((effect.effectType === 'Terrain' || eventid === 'Terrain') &&
 				eventid !== 'Residual' && eventid !== 'End' && this.field.suppressingTerrain()) {
 				this.debug(eventid + ' handler suppressed by Midnight');
 				continue;
-			}
+			}*/
 			let returnVal;
 			if (typeof handler.callback === 'function') {
 				const parentEffect = this.effect;

--- a/sim/field.ts
+++ b/sim/field.ts
@@ -163,22 +163,7 @@ export class Field {
 		return true;
 	}
 	
-	suppressingTerrain(){
-		for (const side of this.battle.sides) {
-			for (const pokemon of side.active) {
-				if (pokemon && !pokemon.ignoringAbility() && pokemon.getAbility().suppressTerrain) {
-					return true;
-				}
-			}
-		}
-		return false;
-	}
-	
 	effectiveTerrain(target?: Pokemon | Side | Battle) {
-		if (this.suppressingTerrain()){
-			console.log("Terrain is suppressed");
-			return '';
-		}
 		if (this.battle.event && !target) target = this.battle.event.target;
 		return this.battle.runEvent('TryTerrain', target) ? this.terrain : '';
 	}


### PR DESCRIPTION
Gen 2 Doubles: Implementing spread damage reduction and screen protection variance

Earth & Sky: Removing global battle.ts and field.ts edits (I tested this BOTH IN E&S AND IN REGULAR FORMATS and it doesn't crash) as they now work within the mod