### PR TITLE
Gen 1 KEP: Fix Metal Sound, Flash Cannon, and Dark VS Psychic

### DIFF
--- a/data/mods/gen1expansionpack/moves.ts
+++ b/data/mods/gen1expansionpack/moves.ts
@@ -409,6 +409,13 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		category: "Physical",
 		type: "Steel",
 		gen: 1,
+		secondary: {
+			chance: 10,
+			boosts: {
+				spa: -1,
+				spd: -1,
+			},
+		},
 	},
 	fly: {
 		inherit: true,
@@ -599,6 +606,10 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		category: "Status",
 		type: "Steel",
 		gen: 1,
+		boosts: {
+			spd: -2,
+			spa: -2,
+		},
 	},
 	metronome: {
 		inherit: true,

--- a/data/mods/gen1expansionpack/typechart.ts
+++ b/data/mods/gen1expansionpack/typechart.ts
@@ -206,7 +206,7 @@ export const TypeChart: {[k: string]: ModdedTypeData} = {
 	"Psychic": {
 		damageTaken: {
 			"Bug": 1,
-			"Dark": 2,
+			"Dark": 1,
 			"Dragon": 0,
 			"Electric": 0,
 			"Fairy": 0,


### PR DESCRIPTION
Metal Sound and Flash Cannon drop SpD, but for Special to be dropped in the Gen 1 sim, both SpA and SpD must be considered. ausma did not know this when programming the moves, which is why Fake Tears didn't work either.

Dark was 0.5x vs Psychic for some reason and it took _checks notes_ a week or two for it to get noticed.