### PR TITLE
Teambuilder fix for abilitypos and impersonators

### DIFF
--- a/data/mods/abilitypos/formats-data.ts
+++ b/data/mods/abilitypos/formats-data.ts
@@ -1,0 +1,20 @@
+export const FormatsData: {[k: string]: SpeciesFormatsData} = {
+	sceptile: {
+		tier: "Abilitypos",
+	},
+	charizard: {
+		tier: "Abilitypos",
+	},
+	inteleon: {
+		tier: "Abilitypos",
+	},
+	lanturn: {
+		tier: "Abilitypos",
+	},
+	larvesta: {
+		tier: "Abilitypos",
+	},
+	aggron: {
+		tier: "Abilitypos",
+	},
+};

--- a/data/mods/impv2/formats-data.ts
+++ b/data/mods/impv2/formats-data.ts
@@ -74,4 +74,13 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 	bibarelpolitoed: {
 		tier: "Imp V2",
 	},
+	fraxurevespiquen: {
+		tier: "Imp V2",
+	},
+	qwilfishkomala: {
+		tier: "Imp V2",
+	},
+	galladegogoat: {
+		tier: "Imp V2",
+	},
 };


### PR DESCRIPTION
Created a formats-data.ts file for abilitypos and added mons from new impersonators slate into the formats-data.ts file.