### PR TITLE
Fix gens 1-5 moves condition lookup

### DIFF
--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -275,7 +275,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		desc: "This attack charges on the first turn and executes on the second. On the first turn, the user avoids all attacks other than Bide, Swift, and Transform. If the user is fully paralyzed on the second turn, it continues avoiding attacks until it switches out or successfully executes the second turn of this move or Fly.",
 		basePower: 100,
-		effect: {
+		condition: {
 			duration: 2,
 			onLockMove: 'dig',
 			onInvulnerability(target, source, move) {
@@ -297,7 +297,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		desc: "For 0 to 7 turns, one of the target's known moves that has at least 1 PP remaining becomes disabled, at random. Fails if one of the target's moves is already disabled, or if none of the target's moves have PP remaining. If any Pokemon uses Haze, this effect ends. Whether or not this move was successful, it counts as a hit for the purposes of the opponent's use of Rage.",
 		shortDesc: "For 0-7 turns, disables one of the target's moves.",
-		effect: {
+		condition: {
 			duration: 4,
 			durationCallback(target, source, effect) {
 				const duration = this.random(1, 7);
@@ -412,7 +412,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	fly: {
 		inherit: true,
 		desc: "This attack charges on the first turn and executes on the second. On the first turn, the user avoids all attacks other than Bide, Swift, and Transform. If the user is fully paralyzed on the second turn, it continues avoiding attacks until it switches out or successfully executes the second turn of this move or Dig.",
-		effect: {
+		condition: {
 			duration: 2,
 			onLockMove: 'fly',
 			onInvulnerability(target, source, move) {
@@ -434,7 +434,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		desc: "While the user remains active, its chance for a critical hit is quartered. Fails if the user already has the effect. If any Pokemon uses Haze, this effect ends.",
 		shortDesc: "Quarters the user's chance for a critical hit.",
-		effect: {
+		condition: {
 			onStart(pokemon) {
 				this.add('-start', pokemon, 'move: Focus Energy');
 			},

--- a/data/mods/gen2/moves.ts
+++ b/data/mods/gen2/moves.ts
@@ -65,7 +65,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		desc: "The user spends two or three turns locked into this move and then, on the second or third turn after using this move, the user attacks the opponent, inflicting double the damage in HP it lost during those turns. If the user is prevented from moving during this move's use, the effect ends. This move does not ignore type immunity.",
 		shortDesc: "Waits 2-3 turns; deals double the damage taken.",
-		effect: {
+		condition: {
 			duration: 3,
 			durationCallback(target, source, effect) {
 				return this.random(3, 5);
@@ -153,7 +153,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		},
 		beforeTurnCallback() {},
 		onTryHit() {},
-		effect: {},
+		condition: {},
 		priority: -1,
 	},
 	crabhammer: {
@@ -167,7 +167,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	curse: {
 		inherit: true,
 		desc: "If the user is not a Ghost type, lowers the user's Speed by 1 stage and raises the user's Attack and Defense by 1 stage, unless the user's Attack and Defense stats are both at stage 6. If the user is a Ghost type, the user loses 1/2 of its maximum HP, rounded down and even if it would cause fainting, in exchange for the target losing 1/4 of its maximum HP, rounded down, at the end of each turn while it is active. If the target uses Baton Pass, the replacement will continue to be affected. Fails if the target is already affected or has a substitute.",
-		effect: {
+		condition: {
 			onStart(pokemon, source) {
 				this.add('-start', pokemon, 'Curse', '[of] ' + source);
 			},
@@ -335,7 +335,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		desc: "Raises the user's chance for a critical hit by 1 stage. Fails if the user already has the effect. Baton Pass can be used to transfer this effect to an ally.",
 		shortDesc: "Raises the user's critical hit ratio by 1.",
-		effect: {
+		condition: {
 			onStart(pokemon) {
 				this.add('-start', pokemon, 'move: Focus Energy');
 			},
@@ -414,7 +414,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	leechseed: {
 		inherit: true,
 		onHit() {},
-		effect: {
+		condition: {
 			onStart(target) {
 				this.add('-start', target, 'move: Leech Seed');
 			},
@@ -441,7 +441,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		desc: "For 5 turns, the user and its party members have their Special Defense doubled. Critical hits ignore this effect. Fails if the effect is already active on the user's side.",
 		shortDesc: "For 5 turns, the user's party has doubled Sp. Def.",
-		effect: {
+		condition: {
 			duration: 5,
 			// Sp. Def boost applied directly in stat calculation
 			onStart(side) {
@@ -515,7 +515,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		},
 		beforeTurnCallback() {},
 		onTryHit() {},
-		effect: {},
+		condition: {},
 		priority: -1,
 	},
 	mirrormove: {
@@ -568,7 +568,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	},
 	nightmare: {
 		inherit: true,
-		effect: {
+		condition: {
 			noCopy: true,
 			onStart(pokemon) {
 				if (pokemon.status !== 'slp') {
@@ -673,7 +673,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		desc: "For 5 turns, the user and its party members have their Defense doubled. Critical hits ignore this effect. Fails if the effect is already active on the user's side.",
 		shortDesc: "For 5 turns, the user's party has doubled Def.",
-		effect: {
+		condition: {
 			duration: 5,
 			// Defense boost applied directly in stat calculation
 			onStart(side) {
@@ -801,7 +801,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		desc: "Sets up a hazard on the opposing side of the field, causing each opposing Pokemon that switches in to lose 1/8 of their maximum HP, rounded down, unless it is a Flying-type Pokemon. Fails if the effect is already active on the opposing side. Can be removed from the opposing side if any opposing Pokemon uses Rapid Spin successfully.",
 		shortDesc: "Hurts grounded foes on switch-in. Max 1 layer.",
-		effect: {
+		condition: {
 			// this is a side condition
 			onStart(side) {
 				if (!this.effectData.layers || this.effectData.layers === 0) {

--- a/data/mods/gen2crystalseviiislands/moves.ts
+++ b/data/mods/gen2crystalseviiislands/moves.ts
@@ -170,7 +170,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 					return false;
 				   }
 			   },
-			 onAfterMoveSecondarySelf(pokemon, source, move) {
+			 onAfterMoveSelf(pokemon, source, move) {
 					if ((!pokemon.hasType('Fire')) && (!pokemon.hasType('Flying')) && (move.id !== 'rapidspin')) {
 						pokemon.trySetStatus('brn', source);
 					}

--- a/data/mods/gen3/moves.ts
+++ b/data/mods/gen3/moves.ts
@@ -52,7 +52,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		desc: "The user spends two turns locked into this move and then, on the second turn after using this move, the user attacks the last Pokemon that hit it, inflicting double the damage in HP it lost during the two turns. If the last Pokemon that hit it is no longer active, the user attacks a random opposing Pokemon instead. If the user is prevented from moving during this move's use, the effect ends. This move does not ignore type immunity.",
 		accuracy: 100,
 		priority: 0,
-		effect: {
+		condition: {
 			duration: 3,
 			onLockMove: 'bide',
 			onStart(pokemon) {
@@ -184,7 +184,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	counter: {
 		inherit: true,
 		desc: "Deals damage to the last opposing Pokemon to hit the user with a physical attack this turn equal to twice the HP lost by the user from that attack. If that opposing Pokemon's position is no longer in use and there is another opposing Pokemon on the field, the damage is done to it instead. This move considers Hidden Power as Normal type, and only the last hit of a multi-hit attack is counted. Fails if the user was not hit by an opposing Pokemon's physical attack this turn, or if the user did not lose HP from the attack.",
-		effect: {
+		condition: {
 			duration: 1,
 			noCopy: true,
 			onStart(target, source, move) {
@@ -237,7 +237,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		shortDesc: "For 2-5 turns, disables the target's last move.",
 		flags: {protect: 1, mirror: 1, authentic: 1},
 		volatileStatus: 'disable',
-		effect: {
+		condition: {
 			durationCallback() {
 				return this.random(2, 6);
 			},
@@ -337,7 +337,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		shortDesc: "The target repeats its last move for 3-6 turns.",
 		flags: {protect: 1, mirror: 1, authentic: 1},
 		volatileStatus: 'encore',
-		effect: {
+		condition: {
 			durationCallback() {
 				return this.random(3, 7);
 			},
@@ -562,7 +562,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	mirrorcoat: {
 		inherit: true,
 		desc: "Deals damage to the last opposing Pokemon to hit the user with a special attack this turn equal to twice the HP lost by the user from that attack. If that opposing Pokemon's position is no longer in use and there is another opposing Pokemon on the field, the damage is done to it instead. This move considers Hidden Power as Normal type, and only the last hit of a multi-hit attack is counted. Fails if the user was not hit by an opposing Pokemon's special attack this turn, or if the user did not lose HP from the attack.",
-		effect: {
+		condition: {
 			duration: 1,
 			noCopy: true,
 			onStart(target, source, move) {
@@ -802,7 +802,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		desc: "The user's Stockpile count increases by 1. Fails if the user's Stockpile count is 3. The user's Stockpile count is reset to 0 when it is no longer active.",
 		shortDesc: "Raises user's Stockpile count by 1. Max 3 uses.",
 		pp: 10,
-		effect: {
+		condition: {
 			noCopy: true,
 			onStart(target) {
 				this.effectData.layers = 1;
@@ -853,7 +853,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		desc: "For 2 turns, prevents the target from using non-damaging moves.",
 		shortDesc: "For 2 turns, the target can't use status moves.",
 		flags: {protect: 1, authentic: 1},
-		effect: {
+		condition: {
 			duration: 2,
 			onStart(target) {
 				this.add('-start', target, 'move: Taunt');

--- a/data/mods/gen4/moves.ts
+++ b/data/mods/gen4/moves.ts
@@ -96,7 +96,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			move.allies = pokemon.side.pokemon.filter(ally => !ally.fainted && !ally.status);
 			move.multihit = move.allies.length;
 		},
-		effect: {
+		condition: {
 			duration: 1,
 			onModifyAtkPriority: -101,
 			onModifyAtk(atk, pokemon, defender, move) {
@@ -337,7 +337,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		desc: "The user is protected from most attacks made by other Pokemon during this turn. This move has a 1/X chance of being successful, where X starts at 1 and doubles each time this move is successfully used, up to a maximum of 8. X resets to 1 if this move fails or if the user's last move used is not Detect, Endure, or Protect. Fails if the user moves last this turn.",
 		priority: 3,
-		effect: {
+		condition: {
 			duration: 1,
 			onStart(target) {
 				this.add('-singleturn', target, 'Protect');
@@ -368,7 +368,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		shortDesc: "For 4-7 turns, disables the target's last move.",
 		flags: {protect: 1, mirror: 1, authentic: 1},
 		volatileStatus: 'disable',
-		effect: {
+		condition: {
 			durationCallback() {
 				return this.random(4, 8);
 			},
@@ -504,7 +504,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		shortDesc: "The target repeats its last move for 4-8 turns.",
 		flags: {protect: 1, mirror: 1, authentic: 1},
 		volatileStatus: 'encore',
-		effect: {
+		condition: {
 			durationCallback() {
 				return this.random(4, 9);
 			},
@@ -761,7 +761,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		desc: "For 5 turns, the target is prevented from restoring any HP as long as it remains active. During the effect, healing moves are unusable, move effects that grant healing will not heal, but Abilities and items will continue to heal the user. If an affected Pokemon uses Baton Pass, the replacement will remain under the effect. Pain Split is unaffected.",
 		flags: {protect: 1, mirror: 1},
-		effect: {
+		condition: {
 			duration: 5,
 			durationCallback(target, source, effect) {
 				if (source?.hasAbility('persistent')) {
@@ -805,7 +805,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		onAfterMove(pokemon) {
 			pokemon.switchFlag = true;
 		},
-		effect: {
+		condition: {
 			duration: 1,
 			onSwitchInPriority: -1,
 			onSwitchIn(target) {
@@ -896,7 +896,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	lightscreen: {
 		inherit: true,
 		desc: "For 5 turns, the user and its party members take 1/2 damage from special attacks, or 2/3 damage if there are multiple active Pokemon on the user's side. Critical hits ignore this effect. It is removed from the user's side if the user or an ally is successfully hit by Brick Break or Defog. Lasts for 8 turns if the user is holding Light Clay. Fails if the effect is already active on the user's side.",
-		effect: {
+		condition: {
 			duration: 5,
 			durationCallback(target, source, effect) {
 				if (source?.hasItem('lightclay')) {
@@ -925,7 +925,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	lockon: {
 		inherit: true,
 		desc: "Until the end of the next turn, the target cannot avoid the user's moves, even if the target is in the middle of a two-turn move. When this effect is started against the target, this and Mind Reader's effects end for every other Pokemon against that target. If the target leaves the field using Baton Pass, the replacement remains under this effect. If the user leaves the field using Baton Pass, this effect is restarted against the same target for the replacement. The effect ends if either the user or the target leaves the field.",
-		effect: {
+		condition: {
 			duration: 2,
 			onSourceInvulnerabilityPriority: 1,
 			onSourceInvulnerability(target, source, move) {
@@ -947,7 +947,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		onAfterMove(pokemon) {
 			pokemon.switchFlag = true;
 		},
-		effect: {
+		condition: {
 			duration: 1,
 			onStart(side) {
 				this.debug('Lunar Dance started on ' + side.name);
@@ -975,7 +975,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	magiccoat: {
 		inherit: true,
 		desc: "The user is unaffected by certain non-damaging moves directed at it and will instead use such moves against the original user. If the move targets both opposing Pokemon, the Pokemon under this effect will reflect the move only targeting the original user. The effect ends once a move is reflected or at the end of the turn. The Lightning Rod and Storm Drain Abilities redirect their respective moves before this move takes effect.",
-		effect: {
+		condition: {
 			duration: 1,
 			onTryHitPriority: 2,
 			onTryHit(target, source, move) {
@@ -1001,7 +1001,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		desc: "For 5 turns, the user is immune to Ground-type attacks and the effects of Spikes, Toxic Spikes, and the Arena Trap Ability as long as it remains active. If the user uses Baton Pass, the replacement will gain the effect. Ingrain and Iron Ball override this move if the user is under any of their effects. Fails if the user is already under this effect or the effect of Ingrain.",
 		flags: {gravity: 1},
 		volatileStatus: 'magnetrise',
-		effect: {
+		condition: {
 			duration: 5,
 			onStart(target) {
 				if (target.volatiles['ingrain'] || target.ability === 'levitate') return false;
@@ -1028,7 +1028,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	mefirst: {
 		inherit: true,
 		desc: "The user uses the move the target chose for use this turn against it, if possible, with its power multiplied by 1.5. The move must be a damaging move other than Chatter, Counter, Covet, Focus Punch, Mirror Coat, or Thief. Fails if the target moves before the user. Ignores the target's substitute for the purpose of copying the move.",
-		effect: {
+		condition: {
 			duration: 1,
 			onModifyDamagePhase2(damage) {
 				return damage * 1.5;
@@ -1154,7 +1154,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		desc: "While the user is active, all Electric-type attacks used by any active Pokemon have their power halved. Fails if this effect is already active for the user. Baton Pass can be used to transfer this effect to an ally.",
 		shortDesc: "Weakens Electric-type attacks to 1/2 their power.",
-		effect: {
+		condition: {
 			noCopy: true,
 			onStart(pokemon) {
 				this.add('-start', pokemon, 'move: Mud Sport');
@@ -1226,7 +1226,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		desc: "The user is protected from most attacks made by other Pokemon during this turn. This move has a 1/X chance of being successful, where X starts at 1 and doubles each time this move is successfully used, up to a maximum of 8. X resets to 1 if this move fails or if the user's last move used is not Detect, Endure, or Protect. Fails if the user moves last this turn.",
 		priority: 3,
-		effect: {
+		condition: {
 			duration: 1,
 			onStart(target) {
 				this.add('-singleturn', target, 'Protect');
@@ -1294,7 +1294,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	reflect: {
 		inherit: true,
 		desc: "For 5 turns, the user and its party members take 1/2 damage from physical attacks, or 2/3 damage if there are multiple active Pokemon on the user's side. Critical hits ignore this effect. It is removed from the user's side if the user or an ally is successfully hit by Brick Break or Defog. Lasts for 8 turns if the user is holding Light Clay. Fails if the effect is already active on the user's side.",
-		effect: {
+		condition: {
 			duration: 5,
 			durationCallback(target, source, effect) {
 				if (source?.hasItem('lightclay')) {
@@ -1514,7 +1514,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	},
 	substitute: {
 		inherit: true,
-		effect: {
+		condition: {
 			onStart(target) {
 				this.add('-start', target, 'Substitute');
 				this.effectData.hp = Math.floor(target.maxhp / 4);
@@ -1615,7 +1615,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		desc: "For 3 turns, the user and its party members have their Speed doubled. Fails if this move is already in effect for the user's side.",
 		shortDesc: "For 3 turns, allies' Speed is doubled.",
-		effect: {
+		condition: {
 			duration: 3,
 			durationCallback(target, source, effect) {
 				if (source?.hasAbility('persistent')) {
@@ -1646,7 +1646,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		desc: "For 3 to 5 turns, prevents the target from using non-damaging moves.",
 		shortDesc: "For 3-5 turns, the target can't use status moves.",
 		flags: {protect: 1, mirror: 1, authentic: 1},
-		effect: {
+		condition: {
 			durationCallback() {
 				return this.random(3, 6);
 			},
@@ -1700,7 +1700,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		desc: "Sets up a hazard on the opposing side of the field, poisoning each opposing Pokemon that switches in, unless it is a Flying-type Pokemon or has the Levitate Ability. Can be used up to two times before failing. Opposing Pokemon become poisoned with one layer and badly poisoned with two layers. Can be removed from the opposing side if any opposing Pokemon uses Rapid Spin successfully, is hit by Defog, or a grounded Poison-type Pokemon switches in. Safeguard prevents the opposing party from being poisoned on switch-in, as well as switching in with a substitute.",
 		flags: {},
-		effect: {
+		condition: {
 			// this is a side condition
 			onStart(side) {
 				this.add('-sidestart', side, 'move: Toxic Spikes');
@@ -1775,7 +1775,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		desc: "While the user is active, all Fire-type attacks used by any active Pokemon have their power halved. Fails if this effect is already active for the user. Baton Pass can be used to transfer this effect to an ally.",
 		shortDesc: "Weakens Fire-type attacks to 1/2 their power.",
-		effect: {
+		condition: {
 			noCopy: true,
 			onStart(pokemon) {
 				this.add('-start', pokemon, 'move: Water Sport');
@@ -1804,7 +1804,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		shortDesc: "Next turn, heals 50% of the recipient's max HP.",
 		flags: {heal: 1},
 		slotCondition: 'Wish',
-		effect: {
+		condition: {
 			duration: 2,
 			onResidualOrder: 0.5,
 			onEnd(target) {

--- a/data/mods/gen5/moves.ts
+++ b/data/mods/gen5/moves.ts
@@ -67,7 +67,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		volatileStatus: 'autotomize',
 		onHit(pokemon) {
 		},
-		effect: {
+		condition: {
 			noCopy: true, // doesn't get copied by Baton Pass
 			onStart(pokemon) {
 				if (pokemon.species.weighthg > 1) {
@@ -327,7 +327,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	furycutter: {
 		inherit: true,
 		basePower: 20,
-		effect: {
+		condition: {
 			duration: 2,
 			onStart() {
 				this.effectData.multiplier = 1;
@@ -577,7 +577,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	},
 	lightscreen: {
 		inherit: true,
-		effect: {
+		condition: {
 			duration: 5,
 			durationCallback(target, source, effect) {
 				if (source?.hasItem('lightclay')) {
@@ -651,7 +651,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		desc: "Raises the user's evasiveness by 2 stages. Whether or not the user's evasiveness was changed, Stomp and Steamroller will have their damage doubled if used against the user while it is active.",
 		pp: 20,
-		effect: {
+		condition: {
 			noCopy: true,
 			onSourceModifyDamage(damage, source, target, move) {
 				if (['stomp', 'steamroller'].includes(move.id)) {
@@ -684,7 +684,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		onTryHitField(target, source) {
 			if (source.volatiles['mudsport']) return false;
 		},
-		effect: {
+		condition: {
 			noCopy: true,
 			onStart(pokemon) {
 				this.add("-start", pokemon, 'Mud Sport');
@@ -783,7 +783,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		onHitSide(side, source) {
 			source.addVolatile('stall');
 		},
-		effect: {
+		condition: {
 			duration: 1,
 			onStart(target, source) {
 				this.add('-singleturn', source, 'Quick Guard');
@@ -814,7 +814,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	},
 	reflect: {
 		inherit: true,
-		effect: {
+		condition: {
 			duration: 5,
 			durationCallback(target, source, effect) {
 				if (source?.hasItem('lightclay')) {
@@ -885,7 +885,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		desc: "Has a 30% chance to cause a secondary effect on the target based on the battle terrain. Lowers accuracy by 1 stage on the regular Wi-Fi terrain. The secondary effect chance is not affected by the Serene Grace Ability.",
 		shortDesc: "Effect varies with terrain. (30% chance acc -1)",
-		effect: {
+		condition: {
 			duration: 1,
 			onAfterMoveSecondarySelf(source, target, move) {
 				if (this.randomChance(3, 10)) {
@@ -1039,7 +1039,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	substitute: {
 		inherit: true,
 		desc: "The user takes 1/4 of its maximum HP, rounded down, and puts it into a substitute to take its place in battle. The substitute is removed once enough damage is inflicted on it, or if the user switches out or faints. Baton Pass can be used to transfer the substitute to an ally, and the substitute will keep its remaining HP. Until the substitute is broken, it receives damage from all attacks made by other Pokemon and shields the user from status effects and stat stage changes caused by other Pokemon. The user still takes normal damage from weather and status effects while behind its substitute. If the substitute breaks during a multi-hit attack, the user will take damage from any remaining hits. If a substitute is created while the user is trapped by a binding move, the binding effect ends immediately. Fails if the user does not have enough HP remaining to create a substitute without fainting, or if it already has a substitute.",
-		effect: {
+		condition: {
 			onStart(target) {
 				this.add('-start', target, 'Substitute');
 				this.effectData.hp = Math.floor(target.maxhp / 4);
@@ -1209,7 +1209,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		onTryHitField(target, source) {
 			if (source.volatiles['watersport']) return false;
 		},
-		effect: {
+		condition: {
 			noCopy: true,
 			onStart(pokemon) {
 				this.add("-start", pokemon, 'move: Water Sport');

--- a/sim/global-types.ts
+++ b/sim/global-types.ts
@@ -1,5 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
+import {EventMethods} from './dex-conditions';
+
 type Battle = import('./battle').Battle;
 type BattleQueue = import('./battle-queue').BattleQueue;
 type Field = import('./field').Field;
@@ -154,6 +156,23 @@ interface BasicEffect extends EffectData {
 	gen: number;
 	sourceEffect: string;
 	toString: () => string;
+}
+
+interface PureEffectData extends EffectData, PureEffectEventMethods, EventMethods, EffectData {
+}
+
+interface PureEffectEventMethods {
+	onCopy?: (this: Battle, pokemon: Pokemon) => void
+	onEnd?: (this: Battle, target: Pokemon & Side & Field) => void
+	onRestart?: (this: Battle, target: Pokemon & Side & Field, source: Pokemon) => void
+	durationCallback?: (this: Battle, target: Pokemon, source: Pokemon, effect: Effect | null) => number
+	onStart?: (this: Battle, target: Pokemon & Side & Field, source: Pokemon, sourceEffect: Effect) => void
+}
+
+type ModdedPureEffectData = Partial<PureEffectData> | ModdedEffectData;
+
+interface PureEffect extends Readonly<BasicEffect & PureEffectData> {
+	readonly effectType: 'Status' | 'Condition' | 'Weather'
 }
 
 type ConditionData = import('./dex-conditions').ConditionData;


### PR DESCRIPTION
This should patch every move in gens 1, 2, 3, 4, 5 and mods based on them to work as intended. A lot of moves were misusing a field name of 'effect' where it should have been labelled 'condition' and this caused them to not apply the new functionality for the tiers based upon that generation.

Haven't deleted any code to achieve this so nothing should be at risk of breaking. The interface code added to globals-types is a slightly modified snippet from globals.ts on smogon/pokemon-showdown , commit hash 62e433d5352e3ae495b1e52ac9645dd7b29a063e

It isn't currently used but I believe in the future it should be useful for creating new custom move effects for our pet mods.