### PR TITLE
C:SI Hidden Power Cosmic

### DIFF
--- a/data/mods/gen2crystalseviiislands/moves.ts
+++ b/data/mods/gen2crystalseviiislands/moves.ts
@@ -555,6 +555,22 @@ export const Moves: {[moveid: string]: MoveData} = {
 		type: "Rock",
 		contestType: "Tough",
 	},
+	hiddenpowercosmic: {
+		num: -15,
+		accuracy: 100,
+		basePower: 70,
+		category: "Special",
+		realMove: "Hidden Power",
+		isNonstandard: "Past",
+		name: "Hidden Power Cosmic",
+		pp: 15,
+		priority: 0,
+		flags: {protect: 1, mirror: 1},
+		secondary: null,
+		target: "normal",
+		type: "Cosmic",
+		contestType: "Clever",
+	},
 	rapidspin: {
 		inherit: true,
 		onAfterHit(target, pokemon) {

--- a/sim/dex.ts
+++ b/sim/dex.ts
@@ -768,6 +768,22 @@ export class ModdedDex {
 		];
 		const tr = this.trunc;
 		const stats = {hp: 31, atk: 31, def: 31, spe: 31, spa: 31, spd: 31};
+
+		// Crystal: Sevii Islands Hidden Power sub-function
+		if (this.currentMod === 'gen2crystalseviiislands') {
+			hpTypes.push('Cosmic');
+			const atkDV = tr(ivs.atk / 2);
+			const defDV = tr(ivs.def / 2);
+			const speDV = tr(ivs.spe / 2);
+			const spcDV = tr(ivs.spa / 2);
+			return {
+				type: hpTypes[4 * (atkDV % 4) + (defDV % 4) + ((speDV + 1) % 2)],
+				power: tr(
+					(5 * ((spcDV >> 3) + (2 * (speDV >> 3)) + (4 * (defDV >> 3)) + (8 * (atkDV >> 3))) + (spcDV % 4)) / 2 + 31
+				),
+			};
+		}
+
 		if (this.gen <= 2) {
 			// Gen 2 specific Hidden Power check. IVs are still treated 0-31 so we get them 0-15
 			const atkDV = tr(ivs.atk / 2);
@@ -775,7 +791,7 @@ export class ModdedDex {
 			const speDV = tr(ivs.spe / 2);
 			const spcDV = tr(ivs.spa / 2);
 			return {
-				type: hpTypes[4 * (atkDV % 4) + (defDV % 4)],
+				type: hpTypes[4 * (atkDV % 4) + (defDV % 4) + ((1 + speDV) % 2)],
 				power: tr(
 					(5 * ((spcDV >> 3) + (2 * (speDV >> 3)) + (4 * (defDV >> 3)) + (8 * (atkDV >> 3))) + (spcDV % 4)) / 2 + 31
 				),


### PR DESCRIPTION
Sevii Islands will have its own Hidden Power type subfunction in dex.ts as it's the only place to really add it.

Hidden Power Cosmic is generated by creating a subpattern of types off of an even-numbered Speed DV. Hidden Power Fighting is procedurally 'knocked-off' of this DV pattern and all Hidden Power types are bumped along the chain one stage essentially. Odd-numbered Speed DVs do not change the Hidden Power type and remain identical to base Gen 2, meaning that a perfect Speed DV (fifteen) will not change the Hidden Power type of a Pokemon.