### PR TITLE
Derivative Unova: Unbanning Tornadus-T

### DIFF
--- a/data/mods/gen5derivativeunova/formats-data.ts
+++ b/data/mods/gen5derivativeunova/formats-data.ts
@@ -8,7 +8,7 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	landorus: {
 		tier: "(OU)",
 	},
-	landorustherian: {
+	tornadustherian: {
 		tier: "(OU)",
 	},
 	manaphy: {

--- a/data/mods/gen5derivativeunova/scripts.ts
+++ b/data/mods/gen5derivativeunova/scripts.ts
@@ -1,4 +1,4 @@
-const unbanned = ["genesect", "thundurus", "landorus", "landorustherian", "manaphy"];
+const unbanned = ["genesect", "thundurus", "landorus", "tornadustherian", "manaphy"];
 
 export const Scripts: ModdedBattleScriptsData = {
 	inherit: 'gen5',


### PR DESCRIPTION
Accidentally had Torn-T listed as Lando-T, fixing~