### PR TITLE
SVspec update!

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -3317,6 +3317,7 @@ export const Formats: FormatList = [
 		],
 
 		searchShow: false,
+		
 		ruleset: ['Team Preview', 'HP Percentage Mod', 'Cancel Mod', 'Dynamax Clause', 'Sleep Clause Mod'],
 		onValidateSet(set) {
 			const item = this.dex.getItem(set.item);

--- a/data/mods/m4asandbox/moves.ts
+++ b/data/mods/m4asandbox/moves.ts
@@ -1379,7 +1379,7 @@ export const Moves: {[moveid: string]: ModdedMoveData} = {
 		contestType: "Cool",
 	},
 	victorydance: {
-		shortDesc: "Raises the user's Attack by 2 and Defense by 1.",
+		shortDesc: "Raises the user's and ally's Attack and Defense by 1.",
 		num: -1007,
 		accuracy: true,
 		basePower: 0,
@@ -1393,11 +1393,11 @@ export const Moves: {[moveid: string]: ModdedMoveData} = {
 			this.add('-anim', source, "Quiver Dance", target);
 		},
 		boosts: {
-			atk: 2,
+			atk: 1,
 			def: 1,
 		},
 		secondary: null,
-		target: "self",
+		target: "allies",
 		type: "Fighting",
 		zMove: {boost: {atk: 1}},
 		contestType: "Beautiful",
@@ -1470,7 +1470,7 @@ export const Moves: {[moveid: string]: ModdedMoveData} = {
 		contestType: "Cool",
 	},
 	shelter: {
-		shortDesc: "Raises the user's Defense by 2.",
+		shortDesc: "Raises the user's and ally's Defense by 2.",
 		num: -1011,
 		accuracy: true,
 		basePower: 0,
@@ -1487,7 +1487,7 @@ export const Moves: {[moveid: string]: ModdedMoveData} = {
 			def: 2,
 		},
 		secondary: null,
-		target: "self",
+		target: "allies",
 		type: "Steel",
 		zMove: {effect: 'clearnegativeboost'},
 		contestType: "Tough",
@@ -1850,7 +1850,7 @@ export const Moves: {[moveid: string]: ModdedMoveData} = {
 		contestType: "Tough",
 	},
 	lunarblessing: {
-		shortDesc: "User cures its burn, poison, or paralysis and recovers 1/16 max HP per turn.",
+		shortDesc: "User and allies: healed 1/4 max HP, status cured.",
 		num: -1022,
 		accuracy: true,
 		basePower: 0,

--- a/data/mods/svspeculative/abilities.ts
+++ b/data/mods/svspeculative/abilities.ts
@@ -13,4 +13,27 @@ export const Abilities: {[abilityid: string]: ModdedAbilityData} = {
 			}
 		},
 	},
+	angershell: {
+		shortDesc: "When this Pokémon reaches 1/2 or less of its max HP: +1 Atk/SpA/Spe, -1 Def/SpD.",
+		onAfterMoveSecondary(target, source, move) {
+			if (!source || source === target || !target.hp || !move.totalDamage) return;
+			const lastAttackedBy = target.getLastAttackedBy();
+			if (!lastAttackedBy) return;
+			const damage = move.multihit ? move.totalDamage : lastAttackedBy.damage;
+			if (target.hp <= target.maxhp / 2 && target.hp + damage > target.maxhp / 2) {
+				// this.boost({atk: 1, def: -1, spa: 1, spd: -1, spe: 1});
+				// the above works, but it takes forever! let's make it a shorter display:
+				const angerShellBoost: SparseBoostsTable = {};
+				angerShellBoost.def = -1;
+				angerShellBoost.spd = -1;
+				angerShellBoost.atk = 1;
+				angerShellBoost.spa = 1;
+				angerShellBoost.spe = 1;
+				this.boost(angerShellBoost);
+			}
+		},
+		name: "Anger Shell",
+		rating: 4,
+		num: -1001,
+	},
 };

--- a/data/mods/svspeculative/formats-data.ts
+++ b/data/mods/svspeculative/formats-data.ts
@@ -14,11 +14,6 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	qwilfishhisui: { tier: "SV (NFE)" },
 	overqwil: { tier: "SV" },
 
-	sneasel: { tier: "SV (NFE)" },
-	sneaselhisui: { tier: "SV (NFE)" },
-	weavile: { tier: "SV" },
-	sneasler: { tier: "SV" },
-
 	dialgaorigin: { tier: "Uber" },
 	palkiaorigin: { tier: "Uber" },
 
@@ -180,6 +175,11 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 
 	dunsparce: { tier: "SV" },
 
+	sneasel: { tier: "SV (NFE)" },
+	sneaselhisui: { tier: "SV (NFE)" },
+	weavile: { tier: "SV" },
+	sneasler: { tier: "SV" },
+
 	teddiursa: { tier: "SV (NFE)" },
 	ursaring: { tier: "SV (NFE)" },
 	ursaluna: { tier: "SV (NFE)" },
@@ -222,11 +222,15 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	numel: { tier: "SV (NFE)" },
 	camerupt: { tier: "SV" },
 
+	torkoal: { tier: "SV" },
+
 	cacnea: { tier: "SV (NFE)" },
 	cacturne: { tier: "SV" },
 
 	swablu: { tier: "SV (NFE)" },
 	altaria: { tier: "SV" },
+
+	zangoose: { tier: "SV" },
 
 	seviper: { tier: "SV" },
 
@@ -318,6 +322,19 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 
 	larvesta: { tier: "SV (NFE)" },
 	volcarona: { tier: "SV" },
+
+	chespin: { tier: "SV (NFE)" },
+	quilladin: { tier: "SV (NFE)" },
+	chesnaught: { tier: "SV" },
+
+	fennekin: { tier: "SV (NFE)" },
+	braixen: { tier: "SV (NFE)" },
+	delphox: { tier: "SV" },
+
+	froakie: { tier: "SV (NFE)" },
+	frogadier: { tier: "SV (NFE)" },
+	greninja: { tier: "SV" },
+	greninjaash: { tier: "SV" }, // not confirmed and I kinda hope not o_o but the rest of the line is here
 
 	fletchling: { tier: "SV (NFE)" },
 	fletchinder: { tier: "SV (NFE)" },

--- a/data/mods/svspeculative/formats-data.ts
+++ b/data/mods/svspeculative/formats-data.ts
@@ -91,8 +91,11 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 	arcaninehisui: { tier: "SV" },
 
 	slowpoke: { tier: "SV (NFE)" },
+	slowpokegalar: { tier: "SV (NFE)" },
 	slowbro: { tier: "SV" },
+	slowbrogalar: { tier: "SV" },
 	slowking: { tier: "SV" },
+	slowkinggalar: { tier: "SV" },
 
 	magnemite: { tier: "SV (NFE)" },
 	magneton: { tier: "SV (NFE)" },

--- a/data/mods/svspeculative/moves.ts
+++ b/data/mods/svspeculative/moves.ts
@@ -158,7 +158,7 @@ export const Moves: {[moveid: string]: ModdedMoveData} = {
 		contestType: "Cool",
 	},
 	victorydance: {
-		shortDesc: "Raises the user's Attack by 2 and Defense by 1.",
+		shortDesc: "Raises the user's and ally's Attack and Defense by 1.",
 		num: -1007,
 		accuracy: true,
 		basePower: 0,
@@ -172,11 +172,11 @@ export const Moves: {[moveid: string]: ModdedMoveData} = {
 			this.add('-anim', source, "Quiver Dance", target);
 		},
 		boosts: {
-			atk: 2,
+			atk: 1,
 			def: 1,
 		},
 		secondary: null,
-		target: "self",
+		target: "allies",
 		type: "Fighting",
 		zMove: {boost: {atk: 1}},
 		contestType: "Beautiful",
@@ -249,7 +249,7 @@ export const Moves: {[moveid: string]: ModdedMoveData} = {
 		contestType: "Cool",
 	},
 	shelter: {
-		shortDesc: "Raises the user's Defense by 2.",
+		shortDesc: "Raises the user's and ally's Defense by 2.",
 		num: -1011,
 		accuracy: true,
 		basePower: 0,
@@ -266,7 +266,7 @@ export const Moves: {[moveid: string]: ModdedMoveData} = {
 			def: 2,
 		},
 		secondary: null,
-		target: "self",
+		target: "allies",
 		type: "Steel",
 		zMove: {effect: 'clearnegativeboost'},
 		contestType: "Tough",
@@ -629,7 +629,7 @@ export const Moves: {[moveid: string]: ModdedMoveData} = {
 		contestType: "Tough",
 	},
 	lunarblessing: {
-		shortDesc: "User cures its burn, poison, or paralysis and recovers 1/16 max HP per turn.",
+		shortDesc: "User and allies: healed 1/4 max HP, status cured.",
 		num: -1022,
 		accuracy: true,
 		basePower: 0,
@@ -788,6 +788,7 @@ export const Moves: {[moveid: string]: ModdedMoveData} = {
 		basePower: 0,
 		category: "Status",
 		name: "Shed Tail",
+		shortDesc: "In exchange for half of its HP, switches out and creates a Substitute for the switch-in.",
 		pp: 10,
 		priority: 0,
 		flags: {snatch: 1},
@@ -825,5 +826,50 @@ export const Moves: {[moveid: string]: ModdedMoveData} = {
 		type: "Normal",
 		zMove: {effect: 'heal'},
 		contestType: "Cute",
+	},
+	armorcannon: {
+		num: -1027,
+		accuracy: 100,
+		basePower: 110, // it's a special move
+		category: "Special",
+		name: "Armor Cannon",
+		shortDesc: "Lowers the user's Defense and Sp. Def by 1.",
+		pp: 5,
+		priority: 0,
+		flags: {contact: 1, protect: 1, mirror: 1},
+		onPrepareHit(target, source, move) {
+			this.attrLastMove('[still]');
+			this.add('-anim', source, "Searing Shot", target);
+		},
+		self: {
+			boosts: {
+				def: -1,
+				spd: -1,
+			},
+		},
+		secondary: null,
+		target: "normal",
+		type: "Fire",
+		contestType: "Tough",
+	},
+	bitterblade: {
+		num: -1028,
+		accuracy: 100,
+		basePower: 75,
+		category: "Physical",
+		name: "Bitter Blade",
+		shortDesc: "User recovers 50% of the damage dealt.",
+		pp: 10,
+		priority: 0,
+		flags: {contact: 1, protect: 1, mirror: 1, heal: 1},
+		onPrepareHit(target, source, move) {
+			this.attrLastMove('[still]');
+			this.add('-anim', source, "Shadow Claw", target);
+		},
+		drain: [1, 2],
+		secondary: null,
+		target: "normal",
+		type: "Fire",
+		contestType: "Cool",
 	},
 };

--- a/data/mods/svspeculative/scripts.ts
+++ b/data/mods/svspeculative/scripts.ts
@@ -10,8 +10,61 @@ export const Scripts: ModdedBattleScriptsData = {
 	// Legends stuff + future speculative Fakemon
 
 	init() {
+		const cutMoves = [
+			'karatechop', 'doubleslap', 'cometpunch', 'razorwind', 'Jumpkick', 'rollingkick', 'twineedle', 'sonicboom', 'dragonrage', 'meditate', 'rage', 'barrier',
+			'bide', 'mirrormove', 'eggbomb', 'boneclub', 'clamp', 'spikecannon', 'constrict', 'barrage', 'bubble', 'dizzypunch', 'flash', 'psywave', 'sharpen',
+			'spiderweb', 'nightmare', 'feintattack', 'foresight', 'return', 'frustration', 'magnitude', 'pursuit', 'hiddenpower', 'smellingsalts', 'assist', 'refresh',
+			'snatch', 'secretpower', 'camouflage', 'mudsport', 'iceball', 'needlearm', 'odorsleuth', 'silverwind', 'grasswhistle', 'signalbeam', 'skyuppercut',
+			'watersport', 'miracleeye', 'wakeupslap', 'naturalgift', 'embargo', 'trumpcard', 'healblock', 'wringout', 'luckychant', 'mefirst', 'punishment', 'mudbomb',
+			'mirrorshot', 'rockclimb', 'magnetbomb', 'captivate', 'healorder', 'ominouswind', 'telekinesis', 'flameburst', 'synchronoise', 'chipaway', 'skydrop',
+			'bestow', 'heartstamp', 'steamroller', 'rototiller', 'iondeluge', 'spotlight',
+		];
+		const galarMoves = [
+			'acrobatics', 'agility', 'airslash', 'allyswitch', 'amnesia', 'assurance', 'attract', 'aurasphere', 'avalanche', 'batonpass', 'beatup', 'blazekick',
+			'blizzard', 'bodypress', 'bodyslam', 'bounce', 'bravebird', 'breakingswipe', 'brickbreak', 'brine', 'brutalswing', 'bugbuzz', 'bulkup', 'bulldoze',
+			'bulletseed', 'burningjealousy', 'calmmind', 'charm', 'closecombat', 'coaching', 'corrosivegas', 'cosmicpower', 'crosspoison', 'crunch', 'darkestlariat',
+			'darkpulse', 'dazzlinggleam', 'dig', 'dive', 'dracometeor', 'dragonclaw', 'dragondance', 'dragonpulse', 'drainingkiss', 'drainpunch', 'drillrun',
+			'dualwingbeat', 'earthpower', 'earthquake', 'eerieimpulse', 'electricterrain', 'electroball', 'electroweb', 'encore', 'endure', 'energyball',
+			'expandingforce', 'facade', 'faketears', 'falseswipe', 'fireblast', 'firefang', 'firepunch', 'firespin', 'flamethrower', 'flareblitz', 'flashcannon',
+			'fling', 'flipturn', 'fly', 'focusblast', 'focusenergy', 'foulplay', 'futuresight', 'gigadrain', 'gigaimpact', 'grassknot', 'grassyglide', 'grassyterrain',
+			'guardswap', 'gunkshot', 'gyroball', 'hail', 'heatcrash', 'heatwave', 'heavyslam', 'helpinghand', 'hex', 'highhorsepower', 'hurricane', 'hydropump',
+			'hyperbeam', 'hypervoice', 'icebeam', 'icefang', 'icepunch', 'iciclespear', 'icywind', 'imprison', 'irondefense', 'ironhead', 'irontail', 'lashout',
+			'leafblade', 'leafstorm', 'leechlife', 'lightscreen', 'liquidation', 'lowkick', 'lowsweep', 'magicalleaf', 'magicroom', 'megahorn', 'megakick', 'megapunch',
+			'meteorbeam', 'metronome', 'mistyexplosion', 'mistyterrain', 'muddywater', 'mudshot', 'mysticalfire', 'nastyplot', 'outrage', 'overheat', 'payback', 'payday',
+			'phantomforce', 'pinmissile', 'playrough', 'poisonjab', 'pollenpuff', 'poltergeist', 'powergem', 'powerswap', 'powerwhip', 'protect', 'psychic',
+			'psychicfangs', 'psychicterrain', 'psychocut', 'psyshock', 'raindance', 'razorshell', 'reflect', 'rest', 'retaliate', 'revenge', 'reversal', 'risingvoltage',
+			'rockblast', 'rockslide', 'rocktomb', 'round', 'safeguard', 'sandstorm', 'sandtomb', 'scald', 'scaleshot', 'scaryface', 'scorchingsands', 'screech',
+			'seedbomb', 'selfdestruct', 'shadowball', 'shadowclaw', 'skillswap', 'skittersmack', 'sleeptalk', 'sludgebomb', 'sludgewave', 'smartstrike', 'snarl', 'snore',
+			'solarbeam', 'solarblade', 'speedswap', 'spikes', 'stealthrock', 'steelbeam', 'steelroller', 'steelwing', 'stompingtantrum', 'stoneedge', 'storedpower',
+			'substitute', 'sunnyday', 'superpower', 'surf', 'swift', 'swordsdance', 'tailslap', 'taunt', 'terrainpulse', 'thief', 'throatchop', 'thunder', 'thunderbolt',
+			'thunderfang', 'thunderpunch', 'thunderwave', 'toxicspikes', 'triattack', 'trick', 'trickroom', 'tripleaxel', 'uproar', 'uturn', 'venomdrench', 'venoshock',
+			'voltswitch', 'waterfall', 'weatherball', 'whirlpool', 'wildcharge', 'willowisp', 'wonderroom', 'workup', 'xscissor', 'zenheadbutt',
+		];
 		for (const id in this.dataCache.Pokedex) {
 			if (this.dataCache.Learnsets[id] && this.dataCache.Learnsets[id].learnset) {
+				const learnset = this.dataCache.Learnsets[id].learnset;
+				for (const moveid in learnset) {
+					if (cutMoves.includes(moveid)) {
+						delete learnset[moveid];
+					} else if (galarMoves.includes(moveid)) {
+						learnset[moveid] = ['8M'];
+					} else {
+						let moveSource = null;
+						for (const source of learnset[moveid]) {
+							if (parseInt(source.charAt(0)) < 7) continue; // only recent level/Egg moves
+							if (source.charAt(1) === 'L') {
+								moveSource = ['8L1'];
+								break; // prioritize level-up over Egg if something can be both
+							}
+							if (source.charAt(1) === 'E') moveSource = ['8E'];
+						}
+						if (moveSource) {
+							learnset[moveid] = moveSource;
+						} else {
+							delete learnset[moveid];
+						}
+					}
+				}
 				this.modData('Learnsets', this.toID(id)).learnset.terablast = ["8M"];
 			}
 			const newMon = this.dataCache.Pokedex[id];


### PR DESCRIPTION
Adds the new content from the latest trailer (Anger Shell, Armor Cannon and Bitter Blade), but also attempts to make the teambuilder exclude certain transfer-only moves so that it more realistically represents the format!
The format still follows Custom Game rules and every move is legal, but the learnsets displayed in the teambuilder should now be more limited, which gives useful information.