### PR TITLE
Bust a Move Backlog Clearing

### DIFF
--- a/data/mods/bustamove/moves.ts
+++ b/data/mods/bustamove/moves.ts
@@ -610,7 +610,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			onBeforeMove(pokemon, target, move) {
 				this.add('-message', target.name + " let it's guard down!");
 				this.boost({def: -1}, target, source, move);
-			}
+			},
 		},
 		onMoveAborted(pokemon) {
 				pokemon.removeVolatile('falsesurrender');

--- a/data/mods/bustamove/moves.ts
+++ b/data/mods/bustamove/moves.ts
@@ -1580,7 +1580,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		condition: {
 			duration: 1,
 			onStart(pokemon) {
-				this.add('-singleturn', pokemon, 'move: Shadow Force');
+				//this.add('-singleturn', pokemon, 'move: Shadow Force'); Redundant Text
 				this.add('-message', pokemon.name + " has entered the shadows!");
 			},
 			onSourceModifyDamage(damage, source, target, move) {

--- a/data/mods/bustamove/moves.ts
+++ b/data/mods/bustamove/moves.ts
@@ -603,7 +603,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		flags: {contact: 1, protect: 1, mirror: 1},
 		beforeTurnCallback(pokemon) {
 			pokemon.addVolatile('falsesurrender');
-			this.add('-message', pokemon.name + " bows its head!")
+			this.add('-message', pokemon.name + " bows its head!");
 		},
 		condition: {
 			duration: 1

--- a/data/mods/bustamove/moves.ts
+++ b/data/mods/bustamove/moves.ts
@@ -608,7 +608,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		condition: {
 			duration: 1,
 			onBeforeMove(pokemon, target, move) {
-				this.add('-message', target.name + " let it's guard down!");
+				this.add('-message', target.name + " let its guard down!");
 				this.boost({def: -1}, target, pokemon, move);
 			},
 		},

--- a/data/mods/bustamove/moves.ts
+++ b/data/mods/bustamove/moves.ts
@@ -730,7 +730,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 				}
 			},
 		},
-		target: "all",
+		target: "self",
 		type: "Fairy",
 		zMove: {boost: {def: 1}},
 		contestType: "Beautiful",

--- a/data/mods/bustamove/moves.ts
+++ b/data/mods/bustamove/moves.ts
@@ -1764,6 +1764,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		type: "Electric",
 		contestType: "Cool",
 	},
+	/* Sparkling Aria Currently Crashes the Battle
 	sparklingaria: {
 		num: 664,
 		accuracy: 100,
@@ -1792,6 +1793,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		type: "Water",
 		contestType: "Tough",
 	},
+	*/
 	steamroller: {
 		num: 537,
 		accuracy: 100,

--- a/data/mods/bustamove/moves.ts
+++ b/data/mods/bustamove/moves.ts
@@ -1079,7 +1079,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			onSwap(target) {
 				if (!target.fainted) {
 					target.heal(target.baseMaxhp / 4);
-					this.add('-heal', target, target.getHealth, '[from] move: Life Dew');
+					// this.add('-heal', target, target.getHealth, '[from] move: Life Dew'); Redundant message, and I prefer the flavor text over the generic
 					this.add('-message', target.name + " was revitalized by the Life Dew!");
 					target.side.removeSlotCondition(target, 'lifedew');
 				}

--- a/data/mods/bustamove/moves.ts
+++ b/data/mods/bustamove/moves.ts
@@ -606,7 +606,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			this.add('-message', pokemon.name + " bows its head!");
 		},
 		condition: {
-			duration: 1
+			duration: 1,
 			onBeforeMove(pokemon, target, move) {
 				this.add('-message', target.name + " let it's guard down!");
 				this.boost({def: -1}, target, source, move);

--- a/data/mods/bustamove/moves.ts
+++ b/data/mods/bustamove/moves.ts
@@ -1764,7 +1764,6 @@ export const Moves: {[moveid: string]: MoveData} = {
 		type: "Electric",
 		contestType: "Cool",
 	},
-	/* Sparkling Aria Currently Crashes the Battle
 	sparklingaria: {
 		num: 664,
 		accuracy: 100,
@@ -1779,8 +1778,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			chance: 100,
 			onHit(target, source) {
 				this.add('-activate', source, 'move: Sparkling Aria');
-				const side = source.side;
-				for (const ally of allies) {
+				for (const ally of source.side.pokemon) {
 					if (ally !== source && ally.hasAbility('soundproof')) continue;
 					if (ally.status && ally.status === 'brn') {
 						ally.cureStatus();
@@ -1793,7 +1791,6 @@ export const Moves: {[moveid: string]: MoveData} = {
 		type: "Water",
 		contestType: "Tough",
 	},
-	*/
 	steamroller: {
 		num: 537,
 		accuracy: 100,

--- a/data/mods/bustamove/moves.ts
+++ b/data/mods/bustamove/moves.ts
@@ -484,7 +484,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		flags: {contact: 1, protect: 1, mirror: 1, distance: 1},
 		onTryHit(pokemon) {
 			// will shatter screens through sub, before you hit
-			if (pokemon.runImmunity('Fighting')) {
+			if (pokemon.runImmunity('Flying')) {
 				pokemon.side.removeSideCondition('reflect');
 				pokemon.side.removeSideCondition('lightscreen');
 				pokemon.side.removeSideCondition('auroraveil');

--- a/data/mods/bustamove/moves.ts
+++ b/data/mods/bustamove/moves.ts
@@ -952,7 +952,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		name: "Hyperspace Hole",
 		pp: 15,
 		priority: 0,
-		flags: {mirror: 1, authentic: 1},
+		flags: {protect: 1, mirror: 1, authentic: 1},
 		self: {
 			onHit(source) {
 				this.field.addPseudoWeather('gravity', source);

--- a/data/mods/bustamove/moves.ts
+++ b/data/mods/bustamove/moves.ts
@@ -602,7 +602,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {contact: 1, protect: 1, mirror: 1},
 		condition: {
-			onStart(target, source, move) {
+			onBeforeMove(pokemon, target, move) {
 				this.add('-message', target.name + " let it's guard down!");
 				this.boost({def: -1}, target, source, move);
 			}

--- a/data/mods/bustamove/moves.ts
+++ b/data/mods/bustamove/moves.ts
@@ -601,11 +601,22 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 10,
 		priority: 0,
 		flags: {contact: 1, protect: 1, mirror: 1},
+		beforeTurnCallback(pokemon) {
+			pokemon.addVolatile('falsesurrender');
+			this.add('-message', pokemon.name + " bows its head!")
+		},
 		condition: {
+			duration: 1
 			onBeforeMove(pokemon, target, move) {
 				this.add('-message', target.name + " let it's guard down!");
 				this.boost({def: -1}, target, source, move);
 			}
+		},
+		onMoveAborted(pokemon) {
+				pokemon.removeVolatile('falsesurrender');
+		},
+		onAfterMove(pokemon) {
+			pokemon.removeVolatile('falsesurrender');
 		},
 		secondary: null,
 		target: "normal",

--- a/data/mods/bustamove/moves.ts
+++ b/data/mods/bustamove/moves.ts
@@ -464,24 +464,22 @@ export const Moves: {[moveid: string]: MoveData} = {
 		num: 65,
 		accuracy: 100,
 		basePower: 80,
-		basePowerCallback(pokemon, target, move) {
-			const targetSide = target.side;
-			const sideConditions = [
-				'lightscreen', 'reflect', 'auroraveil',
-			];
-			for (const id of sideConditions) {
-				if(targetSide.sideConditions[id]) {
-					return move.basePower * 1.5;
-				}
-			}
-			return move.basePower;
-		},
 		category: "Physical",
 		shortDesc: "Destroys screens, unless the target is immune.",
 		name: "Drill Peck",
 		pp: 20,
 		priority: 0,
 		flags: {contact: 1, protect: 1, mirror: 1, distance: 1},
+		onBasePower(basePower, pokemon, target) {
+			const sideConditions = [
+				'lightscreen', 'reflect', 'auroraveil',
+			];
+			for (const id of sideConditions) {
+				if(target.side.sideConditions[id]) {
+					return this.chainModify(1.5);
+				}
+			}
+		},
 		onTryHit(pokemon) {
 			// will shatter screens through sub, before you hit
 			if (pokemon.runImmunity('Flying')) {

--- a/data/mods/bustamove/moves.ts
+++ b/data/mods/bustamove/moves.ts
@@ -609,7 +609,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			duration: 1,
 			onBeforeMove(pokemon, target, move) {
 				this.add('-message', target.name + " let it's guard down!");
-				this.boost({def: -1}, target, source, move);
+				this.boost({def: -1}, target, pokemon, move);
 			},
 		},
 		onMoveAborted(pokemon) {

--- a/data/mods/bustamove/moves.ts
+++ b/data/mods/bustamove/moves.ts
@@ -1782,7 +1782,6 @@ export const Moves: {[moveid: string]: MoveData} = {
 					if (ally !== source && ally.hasAbility('soundproof')) continue;
 					if (ally.status && ally.status === 'brn') {
 						ally.cureStatus();
-						this.add('-message', ally.name + " was cured of it's burn!");
 					}
 				}
 			},

--- a/data/mods/bustamove/scripts.ts
+++ b/data/mods/bustamove/scripts.ts
@@ -3,6 +3,10 @@ export const Scripts: {[k: string]: ModdedBattleScriptsData} = {
 		/*Template:
 		this.modData('Learnsets', 'pokemon').learnset.move = ['8L1'];
 		delete this.modData('Learnsets', 'pokemon').learnset.move;*/
+		
+		this.modData('Learnsets', 'beedrill').learnset.acupressure = ['8L1'];
+		this.modData('Learnsets', 'cacturne').learnset.acupressure = ['8L1'];
+		
       this.modData('Learnsets', 'ambipom').learnset.armthrust = ['8L1'];
 		this.modData('Learnsets', 'breloom').learnset.armthrust = ['8L1'];
 		this.modData('Learnsets', 'grapploct').learnset.armthrust = ['8L1'];
@@ -26,10 +30,16 @@ export const Scripts: {[k: string]: ModdedBattleScriptsData} = {
 		this.modData('Learnsets', 'raikou').learnset.aurorabeam = ['8L1'];
 		this.modData('Learnsets', 'regice').learnset.aurorabeam = ['8L1'];
 		this.modData('Learnsets', 'starmie').learnset.aurorabeam = ['8L1'];
+		
+		this.modData('Learnsets', 'articunogalar').learnset.avalance = ['8L1'];
 	
 		this.modData('Learnsets', 'honchkrow').learnset.beakblast = ['8L1'];
 		this.modData('Learnsets', 'cramorant').learnset.beakblast = ['8L1'];
 		this.modData('Learnsets', 'mandibuzz').learnset.beakblast = ['8L1'];
+		
+		this.modData('Learnsets', 'lycanrocdusk').learnset.bonerush = ['8L1'];
+		
+		this.modData('Learnsets', 'klinklang').learnset.brickbreak = ['8L1'];
 		
 		this.modData('Learnsets', 'houndoom').learnset.burningjealousy = ['8L1'];
 		this.modData('Learnsets', 'infernape').learnset.burningjealousy = ['8L1'];
@@ -53,6 +63,20 @@ export const Scripts: {[k: string]: ModdedBattleScriptsData} = {
 		this.modData('Learnsets', 'hatterene').learnset.decorate = ['8L1'];
 		this.modData('Learnsets', 'jirachi').learnset.decorate = ['8L1'];
 		this.modData('Learnsets', 'victini').learnset.decorate = ['8L1'];
+		
+		this.modData('Learnsets', 'dedenne').learnset.disarmingvoice = ['8L1'];
+		this.modData('Learnsets', 'eevee').learnset.disarmingvoice = ['8L1'];
+		this.modData('Learnsets', 'jolteon').learnset.disarmingvoice = ['8L1'];
+		this.modData('Learnsets', 'flareon').learnset.disarmingvoice = ['8L1'];
+		this.modData('Learnsets', 'vaporeon').learnset.disarmingvoice = ['8L1'];
+		this.modData('Learnsets', 'espeon').learnset.disarmingvoice = ['8L1'];
+		this.modData('Learnsets', 'umbreon').learnset.disarmingvoice = ['8L1'];
+		this.modData('Learnsets', 'leafeon').learnset.disarmingvoice = ['8L1'];
+		this.modData('Learnsets', 'glaceon').learnset.disarmingvoice = ['8L1'];
+		this.modData('Learnsets', 'sylveon').learnset.disarmingvoice = ['8L1'];
+		this.modData('Learnsets', 'toxel').learnset.disarmingvoice = ['8L1'];	
+		this.modData('Learnsets', 'toxtricity').learnset.disarmingvoice = ['8L1'];
+		this.modData('Learnsets', 'toxtricitylowkey').learnset.disarmingvoice = ['8L1'];
 
       this.modData('Learnsets', 'applin').learnset.dragonhammer = ['8L1'];
 		this.modData('Learnsets', 'flapple').learnset.dragonhammer = ['8L1'];
@@ -60,6 +84,13 @@ export const Scripts: {[k: string]: ModdedBattleScriptsData} = {
 		this.modData('Learnsets', 'emboar').learnset.dragonhammer = ['8L1'];
 		this.modData('Learnsets', 'haxorus').learnset.dragonhammer = ['8L1'];
 		this.modData('Learnsets', 'tyrantrum').learnset.dragonhammer = ['8L1'];
+		
+		this.modData('Learnsets', 'archeops').learnset.drillpeck = ['8L1'];
+		this.modData('Learnsets', 'braviary').learnset.drillpeck = ['8L1'];
+		this.modData('Learnsets', 'staraptor').learnset.drillpeck = ['8L1'];
+		this.modData('Learnsets', 'swanna').learnset.drillpeck = ['8L1'];
+		this.modData('Learnsets', 'talonflame').learnset.drillpeck = ['8L1'];
+		this.modData('Learnsets', 'unfezant').learnset.drillpeck = ['8L1'];
 	
 		this.modData('Learnsets', 'delphox').learnset.eeriespell = ['8L1'];
 		this.modData('Learnsets', 'hatterene').learnset.eeriespell = ['8L1'];
@@ -67,7 +98,17 @@ export const Scripts: {[k: string]: ModdedBattleScriptsData} = {
 		
 		this.modData('Learnsets', 'togepi').learnset.eggbomb = ['8L1'];
 		this.modData('Learnsets', 'togetic').learnset.eggbomb = ['8L1'];
-		this.modData('Learnsets', 'togekiss').learnset.eggbomb = ['8L1']																		
+		this.modData('Learnsets', 'togekiss').learnset.eggbomb = ['8L1'];
+		
+		this.modData('Learnsets', 'carbink').learnset.extrasensory = ['8L1'];
+		this.modData('Learnsets', 'cresselia').learnset.extrasensory = ['8L1'];
+		this.modData('Learnsets', 'diancie').learnset.extrasensory = ['8L1'];
+		this.modData('Learnsets', 'latias').learnset.extrasensory = ['8L1'];
+		this.modData('Learnsets', 'latios').learnset.extrasensory = ['8L1'];
+		this.modData('Learnsets', 'orbeetle').learnset.extrasensory = ['8L1'];
+		this.modData('Learnsets', 'regice').learnset.extrasensory = ['8L1'];
+		this.modData('Learnsets', 'slowking').learnset.extrasensory = ['8L1'];
+		this.modData('Learnsets', 'slowkinggalar').learnset.extrasensory = ['8L1'];
 	
 		this.modData('Learnsets', 'cleffa').learnset.fairywind = ['8L1'];
 		this.modData('Learnsets', 'clefairy').learnset.fairywind = ['8L1'];
@@ -77,6 +118,23 @@ export const Scripts: {[k: string]: ModdedBattleScriptsData} = {
 		this.modData('Learnsets', 'hatterene').learnset.fairywind = ['8L1'];
 		this.modData('Learnsets', 'primarina').learnset.fairywind = ['8L1'];
 		this.modData('Learnsets', 'mew').learnset.fairywind = ['8L1'];
+		
+		this.modData('Learnsets', 'crawdaunt').learnset.falsesurrender = ['8L1'];
+		this.modData('Learnsets', 'hawlucha').learnset.falsesurrender = ['8L1'];
+		this.modData('Learnsets', 'hitmonchan').learnset.falsesurrender = ['8L1'];
+		this.modData('Learnsets', 'hitmonlee').learnset.falsesurrender = ['8L1'];
+		this.modData('Learnsets', 'hitmontop').learnset.falsesurrender = ['8L1'];
+		this.modData('Learnsets', 'pangoro').learnset.falsesurrender = ['8L1'];
+		this.modData('Learnsets', 'persianalola').learnset.falsesurrender = ['8L1'];
+		this.modData('Learnsets', 'thievul').learnset.falsesurrender = ['8L1'];
+		this.modData('Learnsets', 'umbreon').learnset.falsesurrender = ['8L1'];
+		this.modData('Learnsets', 'weavile').learnset.falsesurrender = ['8L1'];
+		
+		this.modData('Learnsets', 'bellossom').learnset.flowershield = ['8L1'];
+		this.modData('Learnsets', 'cutiefly').learnset.flowershield = ['8L1'];
+		this.modData('Learnsets', 'ribombee').learnset.flowershield = ['8L1'];
+		this.modData('Learnsets', 'meganium').learnset.flowershield = ['8L1'];
+		this.modData('Learnsets', 'vileplume').learnset.flowershield = ['8L1'];
 		
 		this.modData('Learnsets', 'aipom').learnset.forcepalm = ['8L1'];
 		this.modData('Learnsets', 'regigigas').learnset.forcepalm = ['8L1'];
@@ -96,10 +154,20 @@ export const Scripts: {[k: string]: ModdedBattleScriptsData} = {
 		this.modData('Learnsets', 'articuno').learnset.glaciate = ['8L1'];
 		this.modData('Learnsets', 'regice').learnset.glaciate = ['8L1'];
 		this.modData('Learnsets', 'suicune').learnset.glaciate = ['8L1'];
+		
+		this.modData('Learnsets', 'excadrill').learnset.guillotine = ['8L1'];
+		this.modData('Learnsets', 'gallade').learnset.guillotine = ['8L1'];
+		this.modData('Learnsets', 'perrserker').learnset.guillotine = ['8L1'];
 
 		this.modData('Learnsets', 'bouffalant').learnset.horndrill = ['8L1'];
 		this.modData('Learnsets', 'dunsparce').learnset.horndrill = ['8L1'];
 	   this.modData('Learnsets', 'fearow').learnset.horndrill = ['8L1'];
+		
+		this.modData('Learnsets', 'beheeyem').learnset.hyperspacehole = ['8L1'];
+		this.modData('Learnsets', 'jirachi').learnset.hyperspacehole = ['8L1'];
+		this.modData('Learnsets', 'necrozma').learnset.hyperspacehole = ['8L1'];
+		this.modData('Learnsets', 'orbeetle').learnset.hyperspacehole = ['8L1'];
+		this.modData('Learnsets', 'starmie').learnset.hyperspacehole = ['8L1'];
 		
 		this.modData('Learnsets', 'arctovish').learnset.iceball = ['8L1'];
 		this.modData('Learnsets', 'arctozolt').learnset.iceball = ['8L1'];
@@ -107,12 +175,42 @@ export const Scripts: {[k: string]: ModdedBattleScriptsData} = {
 		this.modData('Learnsets', 'glalie').learnset.iceball = ['8L1'];
 		this.modData('Learnsets', 'mamoswine').learnset.iceball = ['8L1'];
 		
+		this.modData('Learnsets', 'chimchar').learnset.inferno = ['8L1'];
+		this.modData('Learnsets', 'monferno').learnset.inferno = ['8L1'];
+		this.modData('Learnsets', 'infernape').learnset.inferno = ['8L1'];
+		this.modData('Learnsets', 'cyndaquil').learnset.inferno = ['8L1'];
+		this.modData('Learnsets', 'quilava').learnset.inferno = ['8L1'];
+		this.modData('Learnsets', 'typhlosion').learnset.inferno = ['8L1'];
+		this.modData('Learnsets', 'delphox').learnset.inferno = ['8L1'];
+		this.modData('Learnsets', 'entei').learnset.inferno = ['8L1'];
+		this.modData('Learnsets', 'heatran').learnset.inferno = ['8L1'];
+		this.modData('Learnsets', 'magby').learnset.inferno = ['8L1'];
+		this.modData('Learnsets', 'magmar').learnset.inferno = ['8L1'];
+		this.modData('Learnsets', 'magmortar').learnset.inferno = ['8L1'];
+		this.modData('Learnsets', 'marowakalola').learnset.inferno = ['8L1'];
+		
 		this.modData('Learnsets', 'rockruff').learnset.jawlock = ['8L1'];
 		this.modData('Learnsets', 'lycanroc').learnset.jawlock = ['8L1'];
 		this.modData('Learnsets', 'lycanrocdusk').learnset.jawlock = ['8L1'];
 		this.modData('Learnsets', 'lycanrocmidnight').learnset.jawlock = ['8L1'];
 		this.modData('Learnsets', 'tyrunt').learnset.jawlock = ['8L1'];
 		this.modData('Learnsets', 'tyrantrum').learnset.jawlock = ['8L1'];
+		
+		this.modData('Learnsets', 'dartrix').learnset.leaftornado = ['8L1'];
+		this.modData('Learnsets', 'decidueye').learnset.leaftornado = ['8L1'];
+		this.modData('Learnsets', 'fomantis').learnset.leaftornado = ['8L1'];
+		this.modData('Learnsets', 'lurantis').learnset.leaftornado = ['8L1'];
+		this.modData('Learnsets', 'leafeon').learnset.leaftornado = ['8L1'];
+		this.modData('Learnsets', 'lilligant').learnset.leaftornado = ['8L1'];
+		this.modData('Learnsets', 'tangrowth').learnset.leaftornado = ['8L1'];
+		this.modData('Learnsets', 'treecko').learnset.leaftornado = ['8L1'];
+		this.modData('Learnsets', 'grovyle').learnset.leaftornado = ['8L1'];
+		this.modData('Learnsets', 'sceptile').learnset.leaftornado = ['8L1'];
+		this.modData('Learnsets', 'turtwig').learnset.leaftornado = ['8L1'];
+		this.modData('Learnsets', 'grotle').learnset.leaftornado = ['8L1'];
+		this.modData('Learnsets', 'torterra').learnset.leaftornado = ['8L1'];
+		this.modData('Learnsets', 'virizion').learnset.leaftornado = ['8L1'];
+		this.modData('Learnsets', 'undefined').learnset.leaftornado = ['8L1'];
 		
 		this.modData('Learnsets', 'dewpider').learnset.lifedew = ['8L1'];
 		this.modData('Learnsets', 'araquanid').learnset.lifedew = ['8L1'];
@@ -122,6 +220,14 @@ export const Scripts: {[k: string]: ModdedBattleScriptsData} = {
 		
 		this.modData('Learnsets', 'minccino').learnset.lowsweep = ['8L1'];
 		this.modData('Learnsets', 'cinccino').learnset.lowsweep = ['8L1'];
+		
+		this.modData('Learnsets', 'dedenne').learnset.magneticflux = ['8L1'];
+		this.modData('Learnsets', 'minun').learnset.magneticflux = ['8L1'];
+		this.modData('Learnsets', 'plusle').learnset.magneticflux = ['8L1'];
+		
+		this.modData('Learnsets', 'copperajah').learnset.magnitude = ['8L1'];
+		this.modData('Learnsets', 'groudon').learnset.magnitude = ['8L1'];
+		this.modData('Learnsets', 'steelix').learnset.magnitude = ['8L1'];
 		
 		this.modData('Learnsets', 'bergmite').learnset.mirrorshot = ['8L1'];
 		this.modData('Learnsets', 'avalugg').learnset.mirrorshot = ['8L1'];
@@ -135,6 +241,22 @@ export const Scripts: {[k: string]: ModdedBattleScriptsData} = {
 		this.modData('Learnsets', 'registeel').learnset.mirrorshot = ['8L1'];
 		this.modData('Learnsets', 'sableye').learnset.mirrorshot = ['8L1'];
 		
+		this.modData('Learnsets', 'cutiefly').learnset.mistyexplosion = ['8L1'];
+		this.modData('Learnsets', 'ribombee').learnset.mistyexplosion = ['8L1'];
+		this.modData('Learnsets', 'impidimp').learnset.mistyexplosion = ['8L1'];
+		this.modData('Learnsets', 'morgrem').learnset.mistyexplosion = ['8L1'];
+		this.modData('Learnsets', 'grimmsnarl').learnset.mistyexplosion = ['8L1'];
+		this.modData('Learnsets', 'togepi').learnset.mistyexplosion = ['8L1'];
+		this.modData('Learnsets', 'togetic').learnset.mistyexplosion = ['8L1'];
+		this.modData('Learnsets', 'togekiss').learnset.mistyexplosion = ['8L1'];
+		
+		this.modData('Learnsets', 'darkrai').learnset.nightdaze = ['8L1'];
+		this.modData('Learnsets', 'malamar').learnset.nightdaze = ['8L1'];
+		this.modData('Learnsets', 'spiritomb').learnset.nightdaze = ['8L1'];
+		this.modData('Learnsets', 'umbreon').learnset.nightdaze = ['8L1'];
+		
+		this.modData('Learnsets', 'spectrier').learnset.nightmare = ['8L1'];
+		
 		this.modData('Learnsets', 'blastoise').learnset.octazooka = ['8L1'];
 		this.modData('Learnsets', 'malamar').learnset.octazooka = ['8L1'];
 		
@@ -145,6 +267,18 @@ export const Scripts: {[k: string]: ModdedBattleScriptsData} = {
 		this.modData('Learnsets', 'lanturn').learnset.paraboliccharge = ['8L1'];
 		this.modData('Learnsets', 'electrode').learnset.paraboliccharge = ['8L1'];
 		this.modData('Learnsets', 'rotom').learnset.paraboliccharge = ['8L1'];
+		
+		this.modData('Learnsets', 'ludicolo').learnset.petaldance = ['8L1'];
+		this.modData('Learnsets', 'oricorio').learnset.petaldance = ['8L1'];
+		
+		this.modData('Learnsets', 'poipole').learnset.poisontail = ['8L1'];
+		this.modData('Learnsets', 'naganadel').learnset.poisontail = ['8L1'];
+		this.modData('Learnsets', 'salazzle').learnset.poisontail = ['8L1'];
+		this.modData('Learnsets', 'slowpokegalar').learnset.poisontail = ['8L1'];
+		this.modData('Learnsets', 'slowbrogalar').learnset.poisontail = ['8L1'];
+		this.modData('Learnsets', 'slowkinggalar').learnset.poisontail = ['8L1'];
+		this.modData('Learnsets', 'stunky').learnset.poisontail = ['8L1'];
+		this.modData('Learnsets', 'skuntank').learnset.poisontail = ['8L1'];
 		
 		this.modData('Learnsets', 'diancie').learnset.prismaticlaser = ['8L1'];
 		this.modData('Learnsets', 'espeon').learnset.prismaticlaser = ['8L1'];
@@ -158,13 +292,30 @@ export const Scripts: {[k: string]: ModdedBattleScriptsData} = {
 		this.modData('Learnsets', 'moltresgalar').learnset.razorwind = ['8L1'];
 		this.modData('Learnsets', 'celesteela').learnset.razorwind = ['8L1'];
 		this.modData('Learnsets', 'xatu').learnset.razorwind = ['8L1'];
+		
+		this.modData('Learnsets', 'gigalith').learnset.rockwrecker = ['8L1'];
+		this.modData('Learnsets', 'regirock').learnset.rockwrecker = ['8L1'];
+		this.modData('Learnsets', 'tyranitar').learnset.rockwrecker = ['8L1'];
 
       this.modData('Learnsets', 'toucannon').learnset.selfdestruct = ['8L1'];
+		
+		this.modData('Learnsets', 'dusknoir').learnset.shadowforce = ['8L1'];
+		
+		this.modData('Learnsets', 'glaceon').learnset.sheercold = ['8L1'];
+		this.modData('Learnsets', 'regice').learnset.sheercold = ['8L1'];
 		
 		this.modData('Learnsets', 'wailmer').learnset.sing = ['8L1'];
 		this.modData('Learnsets', 'wailord').learnset.sing = ['8L1'];
 		
 		this.modData('Learnsets', 'vaporeon').learnset.soak = ['8L1'];
+		
+		this.modData('Learnsets', 'elekid').learnset.spark = ['8L1'];
+		this.modData('Learnsets', 'electabuzz').learnset.spark = ['8L1'];
+		this.modData('Learnsets', 'electivire').learnset.spark = ['8L1'];
+		this.modData('Learnsets', 'pincurchin').learnset.spark = ['8L1'];
+		this.modData('Learnsets', 'regieleki').learnset.spark = ['8L1'];
+		this.modData('Learnsets', 'rotom').learnset.spark = ['8L1'];
+		this.modData('Learnsets', 'thundurus').learnset.spark = ['8L1'];
 		
 		this.modData('Learnsets', 'milotic').learnset.sparklingaria = ['8L1'];
 		this.modData('Learnsets', 'phione').learnset.sparklingaria = ['8L1'];
@@ -192,6 +343,12 @@ export const Scripts: {[k: string]: ModdedBattleScriptsData} = {
 		this.modData('Learnsets', 'primarina').learnset.synchronoise = ['8L1'];
 		this.modData('Learnsets', 'silvally').learnset.synchronoise = ['8L1'];
 		this.modData('Learnsets', 'toxtricity').learnset.synchronoise = ['8L1'];
+		
+		this.modData('Learnsets', 'camerupt').learnset.tarshot = ['8L1'];
+		this.modData('Learnsets', 'gastrodon').learnset.tarshot = ['8L1'];
+		this.modData('Learnsets', 'magcargo').learnset.tarshot = ['8L1'];
+		this.modData('Learnsets', 'mukalola').learnset.tarshot = ['8L1'];
+		this.modData('Learnsets', 'torkoal').learnset.tarshot = ['8L1'];
 
 		this.modData('Learnsets', 'porygonz').learnset.technoblast = ['8L1'];
 		
@@ -205,9 +362,30 @@ export const Scripts: {[k: string]: ModdedBattleScriptsData} = {
 		this.modData('Learnsets', 'gengar').learnset.trickortreat = ['8L1'];
 		this.modData('Learnsets', 'sableye').learnset.trickortreat = ['8L1'];
 		
+		this.modData('Learnsets', 'breloom').learnset.triplekick = ['8L1'];
+		
+		this.modData('Learnsets', 'beheeyem').learnset.trumpcard = ['8L1'];
+		this.modData('Learnsets', 'drampa').learnset.trumpcard = ['8L1'];
+		this.modData('Learnsets', 'hatenna').learnset.trumpcard = ['8L1'];
+		this.modData('Learnsets', 'hattrem').learnset.trumpcard = ['8L1'];
+		this.modData('Learnsets', 'hatterene').learnset.trumpcard = ['8L1'];
+		this.modData('Learnsets', 'hoopa').learnset.trumpcard = ['8L1'];
+		this.modData('Learnsets', 'porygon').learnset.trumpcard = ['8L1'];
+		this.modData('Learnsets', 'porygon2').learnset.trumpcard = ['8L1'];
+		this.modData('Learnsets', 'porygonz').learnset.trumpcard = ['8L1'];
+		
 		this.modData('Learnsets', 'nidoranf').learnset.twineedle = ['8L1'];
 		this.modData('Learnsets', 'nidoranm').learnset.twineedle = ['8L1'];
 		this.modData('Learnsets', 'toxapex').learnset.twineedle = ['8L1'];
+		
+		this.modData('Learnsets', 'dracovish').learnset.twister = ['8L1'];
+		this.modData('Learnsets', 'dracozolt').learnset.twister = ['8L1'];
+		this.modData('Learnsets', 'sceptile').learnset.twister = ['8L1'];
+		
+		this.modData('Learnsets', 'boltund').learnset.zapcannon = ['8L1'];
+		this.modData('Learnsets', 'pincurchin').learnset.zapcannon = ['8L1'];
+		this.modData('Learnsets', 'rotom').learnset.zapcannon = ['8L1'];
+		this.modData('Learnsets', 'zeraora').learnset.zapcannon = ['8L1'];
 	},
 /*
 		for (const id in this.dataCache.Pokedex) {

--- a/data/mods/bustamove/scripts.ts
+++ b/data/mods/bustamove/scripts.ts
@@ -210,7 +210,6 @@ export const Scripts: {[k: string]: ModdedBattleScriptsData} = {
 		this.modData('Learnsets', 'grotle').learnset.leaftornado = ['8L1'];
 		this.modData('Learnsets', 'torterra').learnset.leaftornado = ['8L1'];
 		this.modData('Learnsets', 'virizion').learnset.leaftornado = ['8L1'];
-		this.modData('Learnsets', 'undefined').learnset.leaftornado = ['8L1'];
 		
 		this.modData('Learnsets', 'dewpider').learnset.lifedew = ['8L1'];
 		this.modData('Learnsets', 'araquanid').learnset.lifedew = ['8L1'];


### PR DESCRIPTION
With Okis' permission, I've taken on coding what I can for this mod.
Newly altered moves include: Acupressure, Aerial Ace, Avalanche, Bone Rush, Brick Break, Comet Punch (Secondary Effect originally missing), Disarming Voice, Drill Peck, Eerie Impulse, Extrasensory, False Surrender, Flame Wheel, Flower Shield, Guillotine, Hyperspace Hole, Inferno, Iron Tail, Leaf Tornado, Life Dew, Magnetic Flux, Magnitude (and by extent, this slightly alters Grassy Terrain), Misty Explosion, Night Daze, Nightmare, Petal Dance, Poison Tail, Rock Wrecker, Scary Face, Shadow Force, Sheer Cold, Spark, Sparkling Aria, Tar Shot, Triple Kick, Trump Card, Twister, and Zap Cannon.