### PR TITLE
KEP: Fix new moves, ban Scream Tail & Toedscruel

### DIFF
--- a/data/mods/gen1expansionpack/formats-data.ts
+++ b/data/mods/gen1expansionpack/formats-data.ts
@@ -361,11 +361,11 @@ export const FormatsData: {[k: string]: ModdedSpeciesFormatsData} = {
 		gen: 1,
 	},
 	toedscruel: {
-		tier: "New",
+		tier: "Uber",
 		gen: 1,
 	},
 	screamtail: {
-		tier: "New",
+		tier: "Uber",
 		gen: 1,
 	},
 	sandyshocks: {

--- a/data/mods/gen1expansionpack/moves.ts
+++ b/data/mods/gen1expansionpack/moves.ts
@@ -506,8 +506,17 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		willCrit: true,
 		type: "Normal",
 	},
-	kowtowcleave: { // unused but will definitely consider
+	kowtowcleave: { // filled in manually
+		num: -100,
 		inherit: true,
+		basePower: 85,
+		accuracy: true,
+		pp: 10,
+		type: "Dark",
+		target: "normal",
+		secondary: null,
+		priority: 0,
+		name: "Kowtow Cleave",
 	},
 	leechseed: {
 		inherit: true,
@@ -781,10 +790,21 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		accuracy: 65,
 	},
-	ruination: { // unused
+	ruination: { // unused; filled in manually
+		num: -101,
 		inherit: true,
 		ignoreImmunity: true,
 		basePower: 1,
+		accuracy: 90,
+		damageCallback(pokemon, target) {
+			return this.clampIntRange(target.getUndynamaxedHP() / 2, 1);
+		},
+		pp: 10,
+		type: "Dark",
+		target: "normal",
+		secondary: null,
+		priority: 0,
+		name: "Ruination",
 	},
 	sandattack: {
 		inherit: true,
@@ -801,11 +821,19 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		basePower: 130,
 		target: "normal",
 	},
-	shelter: { // unused
+	shelter: { // unused; filled in manually
 		inherit: true,
 		category: "Status",
 		type: "Steel",
 		gen: 1,
+		accuracy: true,
+		basePower: 0,
+		category: "Status",
+		name: "Shelter",
+		pp: 10,
+		secondary: null,
+		target: "self",
+		type: "Steel",
 	},
 	skullbash: {
 		inherit: true,


### PR DESCRIPTION
I forgor :skull:

So when I was force-pushing the SV update I literally just forgot to manually add the new moves. They should at least function now.

Scream Tail and Toedscruel proved to be overbearing in their debut to the metagame, and have thus been banned for the initial tournament. Given that, I'm just sending them to Ubers now, to prevent confusion among new players.

For the sake of transparency and giving people somewhere to look for reasoning, I'll use this space to post.

Scream Tail is one of the bulkiest Pokemon in the game, it's kind of disgusting. This, coupled with unparalleled coverage, means it can get away with murder. It viably runs Rest against even Snorlax and Tauros assaults, which is usually a sign of a problem; it takes less damage from Tauros than a Seismic Toss. While it lacks Recover like, say, Alakazam, what you get in return is offensive pressure that's borderline unbearable. Coupled with those Recover Psychic-types on "PsySpam" teams, it really is just too much. I think there is a world where it can come back, but for now, it's being taken behind the shed.

Toedscruel was an expected one. While generally poor offensively outside of Swords Dance-focused sets, Toedscruel's 100 Speed Spore and Ground typing make it the perfect RBY lead. Teams with slow beaters like a Turn 1 Thunder Wave to immediately get paralysis progress off will get completely flattened by this Pokemon. Toedscruel will swap in and fires off guaranteed sleep, then proceed to win. There is no counterplay outside of a hard commit from Starmie, Scream Tail, or Gengar, all of which are inconsistent and cannot KO Toedscruel in one hit. It furthermore invalidates any Ground-centric strategy, such as Rhyperior or Trampel teams, which are commonly used by beginners, making Toedscruel even more concerning. It's 2019 OU Victreebel or 2021 UU Tentacruel, only synthesised into the perfect wrecking ball. I don't think anyone will miss this Pokemon.